### PR TITLE
Add combat encounter system above solitaire cards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,8 @@ import { lazy, Suspense } from 'react';
 import Header from './components/Header';
 import GameBoard from './components/GameBoard';
 import WinScreen from './components/WinScreen';
+import CombatBar from './combat/CombatBar';
+import CombatOverlay from './combat/CombatOverlay';
 import './App.css';
 
 const AnimatedBackground = lazy(() => import('./background/AnimatedBackground'));
@@ -13,8 +15,10 @@ export default function App() {
         <AnimatedBackground />
       </Suspense>
       <Header />
+      <CombatBar />
       <GameBoard />
       <WinScreen />
+      <CombatOverlay />
     </>
   );
 }

--- a/src/combat/CombatBar.css
+++ b/src/combat/CombatBar.css
@@ -1,0 +1,144 @@
+.combat-bar {
+  display: flex;
+  justify-content: center;
+  padding: 6px 8px;
+  background: rgba(13, 40, 24, 0.85);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid rgba(212, 168, 67, 0.3);
+  flex-shrink: 0;
+}
+
+.combat-bar-inner {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  max-width: 800px;
+  gap: 8px;
+}
+
+.combatant {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  gap: 8px;
+  position: relative;
+}
+
+.hero-side {
+  flex-direction: row;
+}
+
+.monster-side {
+  flex-direction: row-reverse;
+}
+
+.combatant-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.combatant-name {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--gold);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.monster-side .combatant-name {
+  text-align: right;
+}
+
+.combat-vs {
+  font-size: 13px;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.4);
+  flex-shrink: 0;
+  padding: 0 2px;
+}
+
+.combat-sprite {
+  flex-shrink: 0;
+  width: 52px;
+  height: 52px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.3);
+  border: 2px solid rgba(212, 168, 67, 0.4);
+}
+
+.combat-sprite svg {
+  width: 40px;
+  height: 40px;
+}
+
+/* Health bar styles */
+.health-bar-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.health-bar-track {
+  width: 100%;
+  height: 14px;
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 7px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.health-bar-fill {
+  height: 100%;
+  border-radius: 6px;
+  background: #4a8a4a;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 0 6px rgba(74, 138, 74, 0.4);
+}
+
+.health-bar-text {
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.7);
+  font-variant-numeric: tabular-nums;
+}
+
+.monster-side .health-bar-text {
+  text-align: right;
+}
+
+/* Responsive adjustments */
+@media (max-width: 480px) {
+  .combat-sprite {
+    width: 40px;
+    height: 40px;
+  }
+
+  .combat-sprite svg {
+    width: 30px;
+    height: 30px;
+  }
+
+  .combatant-name {
+    font-size: 10px;
+  }
+
+  .health-bar-track {
+    height: 10px;
+  }
+
+  .health-bar-text {
+    font-size: 9px;
+  }
+
+  .combat-vs {
+    font-size: 11px;
+  }
+
+  .damage-flash {
+    font-size: 16px !important;
+  }
+}

--- a/src/combat/CombatBar.tsx
+++ b/src/combat/CombatBar.tsx
@@ -1,0 +1,52 @@
+import { useCombatStore } from '../game/combatStore';
+import HealthBar from './HealthBar';
+import HeroSprite from './HeroSprite';
+import MonsterSprite from './MonsterSprite';
+import DamageFlash from './DamageFlash';
+import './CombatBar.css';
+
+export default function CombatBar() {
+  const heroHp = useCombatStore(s => s.heroHp);
+  const heroMaxHp = useCombatStore(s => s.heroMaxHp);
+  const monsterHp = useCombatStore(s => s.monsterHp);
+  const monsterMaxHp = useCombatStore(s => s.monsterMaxHp);
+  const monsterName = useCombatStore(s => s.monsterName);
+  const lastEvent = useCombatStore(s => s.lastEvent);
+  const eventId = useCombatStore(s => s.eventId);
+  const isActive = useCombatStore(s => s.isActive);
+
+  if (!isActive) return null;
+
+  return (
+    <div className="combat-bar">
+      <div className="combat-bar-inner">
+        {/* Hero side */}
+        <div className="combatant hero-side">
+          <HeroSprite shake={lastEvent?.type === 'monster-attack'} />
+          <div className="combatant-info">
+            <div className="combatant-name">Hero</div>
+            <HealthBar current={heroHp} max={heroMaxHp} side="left" />
+          </div>
+          {lastEvent?.type === 'monster-attack' && (
+            <DamageFlash damage={lastEvent.damage} type="monster-attack" eventId={eventId} />
+          )}
+        </div>
+
+        {/* VS divider */}
+        <div className="combat-vs">VS</div>
+
+        {/* Monster side */}
+        <div className="combatant monster-side">
+          {lastEvent?.type === 'hero-attack' && (
+            <DamageFlash damage={lastEvent.damage} type="hero-attack" eventId={eventId} />
+          )}
+          <div className="combatant-info">
+            <div className="combatant-name">{monsterName}</div>
+            <HealthBar current={monsterHp} max={monsterMaxHp} side="right" />
+          </div>
+          <MonsterSprite shake={lastEvent?.type === 'hero-attack'} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/combat/CombatOverlay.css
+++ b/src/combat/CombatOverlay.css
@@ -1,0 +1,91 @@
+.combat-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.combat-victory {
+  background: radial-gradient(ellipse at center, rgba(50, 40, 10, 0.95) 0%, rgba(20, 15, 5, 0.98) 100%);
+}
+
+.combat-defeat {
+  background: radial-gradient(ellipse at center, rgba(50, 10, 10, 0.95) 0%, rgba(20, 5, 5, 0.98) 100%);
+}
+
+.combat-overlay-content {
+  text-align: center;
+  padding: 40px;
+}
+
+.combat-overlay-icon {
+  font-size: 64px;
+  margin-bottom: 16px;
+}
+
+.combat-victory .combat-overlay-icon {
+  color: var(--gold);
+  filter: drop-shadow(0 0 16px rgba(212, 168, 67, 0.5));
+}
+
+.combat-defeat .combat-overlay-icon {
+  color: #cc3333;
+  filter: drop-shadow(0 0 16px rgba(204, 51, 51, 0.5));
+}
+
+.combat-overlay-title {
+  font-size: 32px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.victory-title {
+  color: var(--gold);
+  text-shadow: 0 0 20px rgba(212, 168, 67, 0.4);
+}
+
+.defeat-title {
+  color: #cc3333;
+  text-shadow: 0 0 20px rgba(204, 51, 51, 0.4);
+}
+
+.combat-overlay-subtitle {
+  font-size: 16px;
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: 32px;
+}
+
+.combat-overlay-btn {
+  padding: 12px 32px;
+  font-size: 16px;
+  font-weight: 600;
+  border: 2px solid;
+  border-radius: 8px;
+  cursor: pointer;
+  background: transparent;
+  transition: background 0.2s, transform 0.1s;
+}
+
+.combat-overlay-btn:active {
+  transform: scale(0.96);
+}
+
+.victory-btn {
+  color: var(--gold);
+  border-color: var(--gold);
+}
+
+.victory-btn:hover {
+  background: rgba(212, 168, 67, 0.15);
+}
+
+.defeat-btn {
+  color: #cc3333;
+  border-color: #cc3333;
+}
+
+.defeat-btn:hover {
+  background: rgba(204, 51, 51, 0.15);
+}

--- a/src/combat/CombatOverlay.tsx
+++ b/src/combat/CombatOverlay.tsx
@@ -1,0 +1,66 @@
+import { motion, AnimatePresence } from 'framer-motion';
+import { useCombatStore } from '../game/combatStore';
+import { useGameStore } from '../game/store';
+import './CombatOverlay.css';
+
+export default function CombatOverlay() {
+  const combatResult = useCombatStore(s => s.combatResult);
+  const resetCombat = useCombatStore(s => s.resetCombat);
+  const monsterName = useCombatStore(s => s.monsterName);
+  const newGame = useGameStore(s => s.newGame);
+
+  const handleNewGame = () => {
+    newGame();
+    resetCombat();
+  };
+
+  return (
+    <AnimatePresence>
+      {combatResult === 'victory' && (
+        <motion.div
+          className="combat-overlay combat-victory"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div
+            className="combat-overlay-content"
+            initial={{ scale: 0.5, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            transition={{ type: 'spring', stiffness: 200, damping: 20, delay: 0.1 }}
+          >
+            <div className="combat-overlay-icon">&#9876;</div>
+            <h2 className="combat-overlay-title victory-title">{monsterName} Defeated!</h2>
+            <p className="combat-overlay-subtitle">Your solitaire prowess has vanquished the beast.</p>
+            <button className="combat-overlay-btn victory-btn" onClick={handleNewGame}>
+              New Battle
+            </button>
+          </motion.div>
+        </motion.div>
+      )}
+
+      {combatResult === 'defeat' && (
+        <motion.div
+          className="combat-overlay combat-defeat"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div
+            className="combat-overlay-content"
+            initial={{ scale: 0.5, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            transition={{ type: 'spring', stiffness: 200, damping: 20, delay: 0.1 }}
+          >
+            <div className="combat-overlay-icon">&#9760;</div>
+            <h2 className="combat-overlay-title defeat-title">Game Over</h2>
+            <p className="combat-overlay-subtitle">The {monsterName.toLowerCase()} has overwhelmed you.</p>
+            <button className="combat-overlay-btn defeat-btn" onClick={handleNewGame}>
+              Try Again
+            </button>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/combat/DamageFlash.tsx
+++ b/src/combat/DamageFlash.tsx
@@ -1,0 +1,39 @@
+import { AnimatePresence, motion } from 'framer-motion';
+
+interface DamageFlashProps {
+  damage: number;
+  type: 'hero-attack' | 'monster-attack';
+  eventId: number;
+}
+
+export default function DamageFlash({ damage, type, eventId }: DamageFlashProps) {
+  const color = type === 'hero-attack' ? '#ff4444' : '#ff8844';
+  const xDir = type === 'hero-attack' ? 10 : -10;
+
+  return (
+    <AnimatePresence mode="popLayout">
+      <motion.div
+        key={eventId}
+        className="damage-flash"
+        initial={{ opacity: 1, y: 0, x: 0, scale: 0.5 }}
+        animate={{ opacity: 0, y: -30, x: xDir, scale: 1.3 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.8, ease: 'easeOut' }}
+        style={{
+          color,
+          fontWeight: 'bold',
+          fontSize: '20px',
+          textShadow: `0 0 8px ${color}, 0 0 4px rgba(0,0,0,0.8)`,
+          position: 'absolute',
+          top: '4px',
+          pointerEvents: 'none',
+          left: type === 'hero-attack' ? undefined : '4px',
+          right: type === 'hero-attack' ? '4px' : undefined,
+          zIndex: 10,
+        }}
+      >
+        -{damage}
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/src/combat/HealthBar.tsx
+++ b/src/combat/HealthBar.tsx
@@ -1,0 +1,33 @@
+import { motion } from 'framer-motion';
+
+interface HealthBarProps {
+  current: number;
+  max: number;
+  side: 'left' | 'right';
+}
+
+function getBarColor(ratio: number): string {
+  if (ratio > 0.6) return '#4a8a4a';
+  if (ratio > 0.3) return '#c4a832';
+  return '#cc3333';
+}
+
+export default function HealthBar({ current, max, side }: HealthBarProps) {
+  const ratio = Math.max(0, current / max);
+  const color = getBarColor(ratio);
+
+  return (
+    <div className="health-bar-container" style={{ direction: side === 'right' ? 'rtl' : 'ltr' }}>
+      <div className="health-bar-track">
+        <motion.div
+          className="health-bar-fill"
+          animate={{ width: `${ratio * 100}%`, backgroundColor: color }}
+          transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+        />
+      </div>
+      <div className="health-bar-text" style={{ direction: 'ltr' }}>
+        {current}/{max}
+      </div>
+    </div>
+  );
+}

--- a/src/combat/HeroSprite.tsx
+++ b/src/combat/HeroSprite.tsx
@@ -1,0 +1,37 @@
+import { motion } from 'framer-motion';
+
+interface HeroSpriteProps {
+  shake: boolean;
+}
+
+export default function HeroSprite({ shake }: HeroSpriteProps) {
+  return (
+    <motion.div
+      className="combat-sprite hero-sprite"
+      animate={shake ? { x: [0, -6, 6, -4, 4, -2, 2, 0] } : { x: 0 }}
+      transition={{ duration: 0.4 }}
+    >
+      <svg viewBox="0 0 64 64" width="60" height="60" fill="none" xmlns="http://www.w3.org/2000/svg">
+        {/* Shield */}
+        <path d="M14 28 L14 46 L24 52 L34 46 L34 28 L24 24 Z" fill="#3a6a9a" stroke="#6aafe0" strokeWidth="1.5" />
+        <path d="M24 28 L24 48" stroke="#6aafe0" strokeWidth="1" />
+        <path d="M17 36 L31 36" stroke="#6aafe0" strokeWidth="1" />
+
+        {/* Sword */}
+        <line x1="40" y1="14" x2="40" y2="48" stroke="#c0c0c0" strokeWidth="2.5" strokeLinecap="round" />
+        <line x1="34" y1="40" x2="46" y2="40" stroke="#d4a843" strokeWidth="2.5" strokeLinecap="round" />
+        <polygon points="40,10 37,16 43,16" fill="#c0c0c0" />
+        <rect x="38" y="48" width="4" height="6" rx="1" fill="#8B4513" />
+
+        {/* Helmet */}
+        <ellipse cx="40" cy="26" rx="10" ry="8" fill="#7a7a7a" stroke="#555" strokeWidth="1" />
+        <rect x="36" y="30" width="8" height="3" rx="1" fill="#333" />
+        <path d="M40 18 L40 14" stroke="#d4a843" strokeWidth="2" strokeLinecap="round" />
+
+        {/* Health cross on shield */}
+        <rect x="22" y="33" width="4" height="10" rx="1" fill="#cc3333" />
+        <rect x="19" y="36" width="10" height="4" rx="1" fill="#cc3333" />
+      </svg>
+    </motion.div>
+  );
+}

--- a/src/combat/MonsterSprite.tsx
+++ b/src/combat/MonsterSprite.tsx
@@ -1,0 +1,61 @@
+import { motion } from 'framer-motion';
+
+interface MonsterSpriteProps {
+  shake: boolean;
+}
+
+export default function MonsterSprite({ shake }: MonsterSpriteProps) {
+  return (
+    <motion.div
+      className="combat-sprite monster-sprite"
+      animate={shake ? { x: [0, 6, -6, 4, -4, 2, -2, 0] } : { x: 0 }}
+      transition={{ duration: 0.4 }}
+    >
+      <svg viewBox="0 0 64 64" width="60" height="60" fill="none" xmlns="http://www.w3.org/2000/svg">
+        {/* Dragon body */}
+        <ellipse cx="32" cy="38" rx="18" ry="14" fill="#8B2500" stroke="#cc4400" strokeWidth="1" />
+
+        {/* Wings */}
+        <path d="M14 30 Q4 16 10 10 Q16 18 20 26 Z" fill="#6a1a00" stroke="#cc4400" strokeWidth="1" />
+        <path d="M50 30 Q60 16 54 10 Q48 18 44 26 Z" fill="#6a1a00" stroke="#cc4400" strokeWidth="1" />
+
+        {/* Head */}
+        <ellipse cx="32" cy="22" rx="10" ry="8" fill="#9B3000" stroke="#cc4400" strokeWidth="1" />
+
+        {/* Horns */}
+        <path d="M24 18 L18 8 L26 16" fill="#5a1a00" stroke="#cc4400" strokeWidth="0.8" />
+        <path d="M40 18 L46 8 L38 16" fill="#5a1a00" stroke="#cc4400" strokeWidth="0.8" />
+
+        {/* Eyes */}
+        <ellipse cx="28" cy="21" rx="2.5" ry="2" fill="#FFD700" />
+        <ellipse cx="36" cy="21" rx="2.5" ry="2" fill="#FFD700" />
+        <ellipse cx="28" cy="21" rx="1" ry="1.8" fill="#1a1a1a" />
+        <ellipse cx="36" cy="21" rx="1" ry="1.8" fill="#1a1a1a" />
+
+        {/* Mouth / Fangs */}
+        <path d="M27 27 Q32 31 37 27" stroke="#cc4400" strokeWidth="1" fill="none" />
+        <polygon points="29,27 30,31 31,27" fill="#fff" />
+        <polygon points="33,27 34,31 35,27" fill="#fff" />
+
+        {/* Fire breath hint */}
+        <circle cx="32" cy="32" r="1.5" fill="#FF6600" opacity="0.7" />
+        <circle cx="30" cy="33" r="1" fill="#FFD700" opacity="0.5" />
+        <circle cx="34" cy="33" r="1" fill="#FFD700" opacity="0.5" />
+
+        {/* Belly scales */}
+        <path d="M24 38 Q28 36 32 38 Q36 36 40 38" stroke="#cc6633" strokeWidth="0.8" fill="none" />
+        <path d="M26 42 Q30 40 34 42 Q38 40 42 42" stroke="#cc6633" strokeWidth="0.8" fill="none" />
+
+        {/* Tail */}
+        <path d="M50 38 Q56 42 58 36 Q60 32 56 34" fill="#8B2500" stroke="#cc4400" strokeWidth="1" />
+        <polygon points="56,34 60,30 58,36" fill="#cc4400" />
+
+        {/* Claws */}
+        <line x1="22" y1="50" x2="18" y2="56" stroke="#cc4400" strokeWidth="1.5" strokeLinecap="round" />
+        <line x1="26" y1="50" x2="24" y2="56" stroke="#cc4400" strokeWidth="1.5" strokeLinecap="round" />
+        <line x1="38" y1="50" x2="40" y2="56" stroke="#cc4400" strokeWidth="1.5" strokeLinecap="round" />
+        <line x1="42" y1="50" x2="46" y2="56" stroke="#cc4400" strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+    </motion.div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import { useGameStore } from '../game/store';
+import { useCombatStore } from '../game/combatStore';
 import { useTimer } from '../hooks/useTimer';
 import { canAutoComplete } from '../game/rules';
 import { COMMIT_HASH } from '../generated/buildInfo';
@@ -6,6 +7,7 @@ import './Header.css';
 
 export default function Header() {
   const newGame = useGameStore(s => s.newGame);
+  const resetCombat = useCombatStore(s => s.resetCombat);
   const undo = useGameStore(s => s.undo);
   const autoCompleteAction = useGameStore(s => s.autoComplete);
   const moves = useGameStore(s => s.moves);
@@ -18,11 +20,16 @@ export default function Header() {
 
   const showAutoComplete = !isWon && canAutoComplete(stock, waste, tableau);
 
+  const handleNewGame = () => {
+    newGame();
+    resetCombat();
+  };
+
   return (
     <header className="header">
       <div className="header-left">
         <span className="header-title">Solitaire</span>
-        <button className="header-btn" onClick={() => newGame()}>New</button>
+        <button className="header-btn" onClick={handleNewGame}>New</button>
         <button className="header-btn" onClick={undo} disabled={undoStack.length === 0}>Undo</button>
         {showAutoComplete && (
           <button className="header-btn" onClick={autoCompleteAction} style={{ color: 'var(--gold)' }}>

--- a/src/game/combatStore.ts
+++ b/src/game/combatStore.ts
@@ -1,0 +1,152 @@
+import { create } from 'zustand';
+import { useGameStore } from './store';
+
+export interface EncounterConfig {
+  monsterName: string;
+  monsterMaxHp: number;
+  monsterAttackDamage: number;
+  heroMaxHp: number;
+}
+
+const DEFAULT_ENCOUNTER: EncounterConfig = {
+  monsterName: 'Dragon',
+  monsterMaxHp: 100,
+  monsterAttackDamage: 10,
+  heroMaxHp: 50,
+};
+
+interface CombatEvent {
+  type: 'hero-attack' | 'monster-attack';
+  damage: number;
+}
+
+interface CombatState {
+  heroHp: number;
+  heroMaxHp: number;
+  monsterHp: number;
+  monsterMaxHp: number;
+  monsterName: string;
+  monsterAttackDamage: number;
+  isActive: boolean;
+  combatResult: 'none' | 'victory' | 'defeat';
+  lastEvent: CombatEvent | null;
+  eventId: number;
+}
+
+interface CombatActions {
+  startCombat: (config?: EncounterConfig) => void;
+  dealDamageToMonster: (damage: number) => void;
+  dealDamageToHero: (damage: number) => void;
+  healMonster: (amount: number) => void;
+  healHero: (amount: number) => void;
+  resetCombat: () => void;
+}
+
+export const useCombatStore = create<CombatState & CombatActions>()((set, get) => ({
+  heroHp: DEFAULT_ENCOUNTER.heroMaxHp,
+  heroMaxHp: DEFAULT_ENCOUNTER.heroMaxHp,
+  monsterHp: DEFAULT_ENCOUNTER.monsterMaxHp,
+  monsterMaxHp: DEFAULT_ENCOUNTER.monsterMaxHp,
+  monsterName: DEFAULT_ENCOUNTER.monsterName,
+  monsterAttackDamage: DEFAULT_ENCOUNTER.monsterAttackDamage,
+  isActive: true,
+  combatResult: 'none',
+  lastEvent: null,
+  eventId: 0,
+
+  startCombat: (config = DEFAULT_ENCOUNTER) => {
+    set({
+      heroHp: config.heroMaxHp,
+      heroMaxHp: config.heroMaxHp,
+      monsterHp: config.monsterMaxHp,
+      monsterMaxHp: config.monsterMaxHp,
+      monsterName: config.monsterName,
+      monsterAttackDamage: config.monsterAttackDamage,
+      isActive: true,
+      combatResult: 'none',
+      lastEvent: null,
+      eventId: 0,
+    });
+  },
+
+  dealDamageToMonster: (damage: number) => {
+    const state = get();
+    if (state.combatResult !== 'none') return;
+    const newHp = Math.max(0, state.monsterHp - damage);
+    set({
+      monsterHp: newHp,
+      lastEvent: { type: 'hero-attack', damage },
+      eventId: state.eventId + 1,
+      combatResult: newHp <= 0 ? 'victory' : 'none',
+    });
+  },
+
+  dealDamageToHero: (damage: number) => {
+    const state = get();
+    if (state.combatResult !== 'none') return;
+    const newHp = Math.max(0, state.heroHp - damage);
+    set({
+      heroHp: newHp,
+      lastEvent: { type: 'monster-attack', damage },
+      eventId: state.eventId + 1,
+      combatResult: newHp <= 0 ? 'defeat' : 'none',
+    });
+  },
+
+  healMonster: (amount: number) => {
+    const state = get();
+    set({
+      monsterHp: Math.min(state.monsterMaxHp, state.monsterHp + amount),
+      combatResult: 'none',
+    });
+  },
+
+  healHero: (amount: number) => {
+    const state = get();
+    set({
+      heroHp: Math.min(state.heroMaxHp, state.heroHp + amount),
+      combatResult: 'none',
+    });
+  },
+
+  resetCombat: () => {
+    get().startCombat();
+  },
+}));
+
+// Subscribe to game store changes to detect combat events
+let prevFoundationLengths = useGameStore.getState().foundations.map(f => f.length);
+let prevStockCycleCount = useGameStore.getState().stockCycleCount;
+
+useGameStore.subscribe((state) => {
+  const combat = useCombatStore.getState();
+  if (!combat.isActive || combat.combatResult !== 'none') return;
+
+  // Detect foundation changes
+  const currentLengths = state.foundations.map(f => f.length);
+  for (let i = 0; i < 4; i++) {
+    if (currentLengths[i] > prevFoundationLengths[i]) {
+      // Card was placed on foundation — deal damage equal to card rank
+      const topCard = state.foundations[i][state.foundations[i].length - 1];
+      if (topCard) {
+        combat.dealDamageToMonster(topCard.rank);
+      }
+    } else if (currentLengths[i] < prevFoundationLengths[i]) {
+      // Card was removed (undo) — heal monster
+      // The removed card's rank equals the previous top card rank = currentLength + 1
+      // since foundations are built A(1), 2, 3... the removed card rank = prevLength
+      const healRank = prevFoundationLengths[i]; // rank equals pile position (A=1, 2=2, etc.)
+      combat.healMonster(healRank);
+    }
+  }
+  prevFoundationLengths = currentLengths;
+
+  // Detect stock cycle changes
+  if (state.stockCycleCount > prevStockCycleCount) {
+    combat.dealDamageToHero(combat.monsterAttackDamage);
+  } else if (state.stockCycleCount < prevStockCycleCount) {
+    // Undo of a stock cycle — heal hero
+    combat.healHero(combat.monsterAttackDamage);
+  }
+  prevStockCycleCount = state.stockCycleCount;
+});

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -11,6 +11,7 @@ function takeSnapshot(state: GameState): Snapshot {
     tableau: state.tableau.map(pile => pile.map(c => ({ ...c }))),
     foundations: state.foundations.map(pile => pile.map(c => ({ ...c }))),
     moves: state.moves,
+    stockCycleCount: state.stockCycleCount,
   };
 }
 
@@ -27,6 +28,7 @@ function createInitialState(drawMode: 1 | 3 = 1): Omit<GameState, 'gameId'> {
     startTime: null,
     isWon: false,
     undoStack: [],
+    stockCycleCount: 0,
   };
 }
 
@@ -90,6 +92,7 @@ export const useGameStore = create<GameState & GameActions>()(
             moves: state.moves + 1,
             startTime: state.startTime ?? Date.now(),
             undoStack: [...state.undoStack, snapshot].slice(-50),
+            stockCycleCount: state.stockCycleCount + 1,
           });
           return;
         }
@@ -172,6 +175,7 @@ export const useGameStore = create<GameState & GameActions>()(
           moves: snapshot.moves,
           undoStack: stack,
           isWon: false,
+          stockCycleCount: snapshot.stockCycleCount,
         });
       },
 
@@ -208,6 +212,7 @@ export const useGameStore = create<GameState & GameActions>()(
         startTime: state.startTime,
         gameId: state.gameId,
         isWon: state.isWon,
+        stockCycleCount: state.stockCycleCount,
       }),
     }
   )

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -15,6 +15,7 @@ export interface Snapshot {
   tableau: Card[][];
   foundations: Card[][];
   moves: number;
+  stockCycleCount: number;
 }
 
 export interface GameState {
@@ -28,6 +29,7 @@ export interface GameState {
   isWon: boolean;
   undoStack: Snapshot[];
   gameId: number;
+  stockCycleCount: number;
 }
 
 export interface MovePayload {

--- a/src/hooks/useResponsive.ts
+++ b/src/hooks/useResponsive.ts
@@ -22,7 +22,7 @@ export function useResponsive(): Dimensions {
 
   return useMemo(() => {
     const gap = size.w < 480 ? 6 : size.w < 1024 ? 10 : 14;
-    const headerHeight = 48;
+    const headerHeight = 48 + 72; // header + combat bar
     const availableWidth = size.w - 16; // 8px padding each side
     const cardWidth = Math.min(Math.floor((availableWidth - 8 * gap) / 7), MAX_CARD_WIDTH);
     const cardHeight = Math.round(cardWidth * CARD_ASPECT_RATIO);


### PR DESCRIPTION
Hero (left) vs Monster (right) combat bar rendered between the header
and game board. Placing cards on foundations deals damage equal to the
card's rank. Cycling through the entire stockpile triggers a monster
attack on the hero. Features animated health bars, SVG character sprites,
floating damage numbers, shake animations, and victory/defeat overlays.
Combat state uses a separate Zustand store that subscribes to game
state changes for event detection. Undo-aware: reversing moves also
reverses combat effects.

https://claude.ai/code/session_015WLDBVnCGUEQAsYuNAPp9D