### PR TITLE
Fix TypeScript build errors and add type checking to PR preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Generate build info
         run: node scripts/generate-build-info.js
 
+      - name: Type check
+        run: npx tsc -b
+
       - name: Build with preview base path
         run: npx vite build --base /sullytear/pr-preview/pr-${{ github.event.number }}/
 

--- a/src/background/BackgroundGradient.tsx
+++ b/src/background/BackgroundGradient.tsx
@@ -61,6 +61,7 @@ export default function BackgroundGradient({ combatState }: Props) {
     mat.uniforms.uTime.value += delta;
 
     const cs = combatState.current;
+    if (!cs) return;
 
     // Determine target colors based on combat state priority
     if (cs.combatResult === 'victory' || cs.isWon) {

--- a/src/background/BurstParticles.tsx
+++ b/src/background/BurstParticles.tsx
@@ -221,6 +221,7 @@ export default function BurstParticles({ effectQueue }: Props) {
 
     // Process queued events
     const queue = effectQueue.current;
+    if (!queue) return;
     while (queue.length > 0) {
       const ev = queue.shift()!;
       processEvent(ev);

--- a/src/background/Particles.tsx
+++ b/src/background/Particles.tsx
@@ -105,6 +105,7 @@ export default function Particles({ combatState }: Props) {
     const posAttr = meshRef.current.geometry.attributes.position;
     const pos = posAttr.array as Float32Array;
     const cs = combatState.current;
+    if (!cs) return;
     const isWon = cs.isWon;
     const speed = isWon || cs.combatResult === 'victory' ? 5 : cs.combatResult === 'defeat' ? 0.3 : 1;
 

--- a/src/game/__tests__/combatStore.test.ts
+++ b/src/game/__tests__/combatStore.test.ts
@@ -10,9 +10,9 @@ function makeCard(suit: Suit, rank: Rank, faceUp = true): Card {
 /**
  * Set game state without triggering combat events, then reset tracking.
  */
-function setupGameState(partial: Parameters<typeof useGameStore.setState>[0]) {
+function setupGameState(partial: Partial<Parameters<typeof useGameStore.setState>[0]>) {
   _withSuppressedEvents(() => {
-    useGameStore.setState(partial);
+    useGameStore.setState(partial as Parameters<typeof useGameStore.setState>[0]);
   });
 }
 


### PR DESCRIPTION
Add null guards for React ref access in BackgroundGradient, Particles, and
BurstParticles components. Fix partial state type in combatStore test helper.
Add tsc -b step to PR preview workflow so type errors are caught before merge.

https://claude.ai/code/session_01AprPFTYg1rfUVyHRe19iop