### PR TITLE
Extract idle animation hook, poison drips, particle shaders/dispatch

### DIFF
--- a/src/background/BurstParticles.tsx
+++ b/src/background/BurstParticles.tsx
@@ -3,38 +3,10 @@ import { useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
 import type { EffectEvent } from './useCombatEffects';
 import { portraitPositions } from '../game/portraitPositions';
+import { burstVertexShader, burstFragmentShader } from './shaders/burst';
+import { processEvent, lerpColor, type SpawnFn } from './burstEffects';
 
 const POOL_SIZE = 300;
-
-const vertexShader = /* glsl */ `
-  precision highp float;
-  attribute float aAlpha;
-  attribute float aSize;
-  attribute vec3 aColor;
-  varying float vAlpha;
-  varying vec3 vColor;
-  void main() {
-    vAlpha = aAlpha;
-    vColor = aColor;
-    vec4 mvPos = modelViewMatrix * vec4(position, 1.0);
-    gl_Position = projectionMatrix * mvPos;
-    gl_PointSize = min(aSize * (800.0 / -mvPos.z), 64.0);
-  }
-`;
-
-const fragmentShader = /* glsl */ `
-  precision highp float;
-  varying float vAlpha;
-  varying vec3 vColor;
-  void main() {
-    float dist = distance(gl_PointCoord, vec2(0.5));
-    float alpha = 1.0 - smoothstep(0.2, 0.5, dist);
-    alpha *= vAlpha;
-    if (alpha < 0.01) discard;
-    // Boost color above 1.0 for HDR bloom pickup
-    gl_FragColor = vec4(vColor * 2.5, alpha);
-  }
-`;
 
 interface ParticleData {
   active: boolean;
@@ -45,25 +17,6 @@ interface ParticleData {
   maxLife: number;
   gravity: number;
   drag: number;
-}
-
-// Color constants
-const C_GREEN = new THREE.Color('#66cc77');
-const C_WHITE = new THREE.Color('#ffffff');
-const C_RED = new THREE.Color('#ff4444');
-const C_HEAL_GREEN = new THREE.Color('#44dd44');
-const C_PURPLE = new THREE.Color('#aa44dd');
-const C_GOLD = new THREE.Color('#d4a843');
-const C_DARK_RED = new THREE.Color('#661111');
-const C_ROYAL_PURPLE = new THREE.Color('#c8a2ff');
-const C_ROYAL_GOLD = new THREE.Color('#ffd866');
-
-function lerpColor(a: THREE.Color, b: THREE.Color, t: number): THREE.Color {
-  return new THREE.Color(
-    a.r + (b.r - a.r) * t,
-    a.g + (b.g - a.g) * t,
-    a.b + (b.b - a.b) * t,
-  );
 }
 
 interface Props {
@@ -107,17 +60,17 @@ export default function BurstParticles({ effectQueue }: Props) {
     return { pool, positions, alphas, sizes, colors, geometry: geo };
   }, []);
 
-  function spawn(
-    count: number,
-    x: number, y: number, z: number,
-    velFn: (i: number) => [number, number, number],
-    color: THREE.Color,
-    size: [number, number],
-    life: [number, number],
-    gravity: number = 0,
-    drag: number = 0.98,
-    colorVariant?: THREE.Color,
-  ) {
+  const spawn: SpawnFn = (
+    count,
+    x, y, z,
+    velFn,
+    color,
+    size,
+    life,
+    gravity = 0,
+    drag = 0.98,
+    colorVariant,
+  ) => {
     for (let n = 0; n < count; n++) {
       const idx = nextIdx.current % POOL_SIZE;
       nextIdx.current++;
@@ -145,97 +98,7 @@ export default function BurstParticles({ effectQueue }: Props) {
       p.gravity = gravity;
       p.drag = drag;
     }
-  }
-
-  function processEvent(ev: EffectEvent) {
-    const isVictory = ev.label === 'victory';
-    const isDefeat = ev.label === 'defeat';
-    const isCombo = ev.label?.startsWith('Combo');
-
-    if (isVictory) {
-      // Gold explosion from center
-      spawn(100, 0, 0, 0,
-        () => [(Math.random() - 0.5) * 0.5, (Math.random() - 0.5) * 0.5, (Math.random() - 0.5) * 0.2],
-        C_GOLD, [0.15, 0.35], [1.5, 3], -0.002, 0.97, C_WHITE);
-      return;
-    }
-    if (isDefeat) {
-      // Dark red particles sinking
-      spawn(50, 0, 4, 0,
-        () => [(Math.random() - 0.5) * 0.3, -Math.random() * 0.15 - 0.05, (Math.random() - 0.5) * 0.1],
-        C_DARK_RED, [0.12, 0.25], [2, 4], 0.005, 0.99, C_RED);
-      return;
-    }
-
-    // Get portrait world positions
-    const [heroX, heroY] = screenToWorld(portraitPositions.hero.x, portraitPositions.hero.y);
-    const [monsterX, monsterY] = screenToWorld(portraitPositions.monster.x, portraitPositions.monster.y);
-
-    switch (ev.type) {
-      case 'hero-attack': {
-        const count = isCombo ? Math.min(60, 20 + ev.damage) : 30;
-        const intensity = isCombo ? 0.4 : 0.3;
-        // Burst from monster (the one being hit)
-        spawn(count, monsterX, monsterY, 0,
-          () => [(Math.random() - 0.5) * intensity, Math.random() * 0.25 + 0.1, (Math.random() - 0.5) * 0.05],
-          C_GREEN, [0.1, 0.25], [0.8, 1.8], -0.003, 0.97, C_WHITE);
-        break;
-      }
-      case 'monster-attack': {
-        // Burst from hero (the one being hit)
-        spawn(25, heroX, heroY, 0,
-          () => [(Math.random() - 0.5) * 0.2, -Math.random() * 0.2 - 0.08, (Math.random() - 0.5) * 0.05],
-          C_RED, [0.08, 0.18], [0.8, 1.5], 0.004, 0.98);
-        break;
-      }
-      case 'hero-heal': {
-        // Gentle float up from hero
-        spawn(20, heroX, heroY, 0,
-          () => [(Math.random() - 0.5) * 0.1, Math.random() * 0.1 + 0.03, (Math.random() - 0.5) * 0.03],
-          C_HEAL_GREEN, [0.08, 0.15], [1, 2], -0.001, 0.99, C_WHITE);
-        break;
-      }
-      case 'poison': {
-        // Spiral outward from monster
-        spawn(20, monsterX, monsterY, 0,
-          (i) => {
-            const angle = (i / 20) * Math.PI * 2;
-            return [Math.cos(angle) * 0.15, Math.sin(angle) * 0.15, (Math.random() - 0.5) * 0.03];
-          },
-          C_PURPLE, [0.1, 0.18], [0.8, 1.5], 0, 0.96);
-        break;
-      }
-      case 'empower': {
-        // Ring expansion from hero
-        spawn(25, heroX, heroY, 0,
-          (i) => {
-            const angle = (i / 25) * Math.PI * 2;
-            return [Math.cos(angle) * 0.18, Math.sin(angle) * 0.18, 0];
-          },
-          C_GOLD, [0.1, 0.2], [0.8, 1.5], 0, 0.97, C_WHITE);
-        break;
-      }
-      case 'face-card': {
-        // Royal Awakening — tier-scaled particle burst from hero
-        const isAwakens = ev.label?.includes('Awakens');
-        const isRises = ev.label?.includes('Rises');
-        const count = isAwakens ? 40 : isRises ? 25 : 15;
-        const speed = isAwakens ? 0.25 : isRises ? 0.18 : 0.1;
-        const baseColor = isAwakens ? C_ROYAL_GOLD : C_ROYAL_PURPLE;
-        const variantColor = isAwakens ? C_WHITE : C_ROYAL_GOLD;
-        const sizeRange: [number, number] = isAwakens ? [0.12, 0.3] : isRises ? [0.1, 0.22] : [0.06, 0.14];
-        const lifeRange: [number, number] = isAwakens ? [1.2, 2.5] : isRises ? [0.8, 1.8] : [0.6, 1.2];
-        spawn(count, heroX, heroY, 0,
-          (n) => {
-            const angle = (n / count) * Math.PI * 2 + Math.random() * 0.3;
-            const r = speed * (0.7 + Math.random() * 0.6);
-            return [Math.cos(angle) * r, Math.sin(angle) * r + 0.05, (Math.random() - 0.5) * 0.05];
-          },
-          baseColor, sizeRange, lifeRange, -0.001, 0.97, variantColor);
-        break;
-      }
-    }
-  }
+  };
 
   // Delayed events waiting for attack wind-up to finish
   const delayedEvents = useRef<{ ev: EffectEvent; fireAt: number }[]>([]);
@@ -252,6 +115,13 @@ export default function BurstParticles({ effectQueue }: Props) {
     // Process queued events — delay attack particles until wind-up ends
     const queue = effectQueue.current;
     if (!queue) return;
+
+    const ctx = {
+      spawn,
+      heroPos: screenToWorld(portraitPositions.hero.x, portraitPositions.hero.y),
+      monsterPos: screenToWorld(portraitPositions.monster.x, portraitPositions.monster.y),
+    };
+
     while (queue.length > 0) {
       const ev = queue.shift()!;
       const isVictory = ev.label === 'victory';
@@ -261,7 +131,7 @@ export default function BurstParticles({ effectQueue }: Props) {
       } else if (!isVictory && !isDefeat && ev.type === 'monster-attack') {
         delayedEvents.current.push({ ev, fireAt: now + MONSTER_ANTICIPATE });
       } else {
-        processEvent(ev);
+        processEvent(ev, ctx);
       }
     }
 
@@ -269,7 +139,7 @@ export default function BurstParticles({ effectQueue }: Props) {
     const pending = delayedEvents.current;
     for (let i = pending.length - 1; i >= 0; i--) {
       if (now >= pending[i].fireAt) {
-        processEvent(pending[i].ev);
+        processEvent(pending[i].ev, ctx);
         pending.splice(i, 1);
       }
     }
@@ -313,8 +183,8 @@ export default function BurstParticles({ effectQueue }: Props) {
   return (
     <points ref={meshRef} geometry={geometry}>
       <shaderMaterial
-        vertexShader={vertexShader}
-        fragmentShader={fragmentShader}
+        vertexShader={burstVertexShader}
+        fragmentShader={burstFragmentShader}
         uniforms={{}}
         transparent
         depthWrite={false}

--- a/src/background/Particles.tsx
+++ b/src/background/Particles.tsx
@@ -2,183 +2,13 @@ import { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import type { CombatVisualState } from './useCombatEffects';
+import { cardsVertexShader, cardsFragmentShader } from './shaders/cards';
 
 const CARD_COUNT = 400;
 
 // Card aspect ratio (~poker card proportions)
 const CARD_W = 0.12;
 const CARD_H = 0.17;
-
-const vertexShader = /* glsl */ `
-  precision highp float;
-
-  attribute vec3 aOffset;      // world position of this card
-  attribute vec4 aRotation;    // xyz = euler seed, w = spin speed
-  attribute float aSize;       // scale multiplier
-  attribute float aSuit;       // 0-3 → suit type
-  attribute vec3 aColor;       // base tint per card
-
-  uniform float uTime;
-  uniform vec3 uTintColor;
-  uniform float uTintStrength;
-
-  varying vec2 vUv;
-  varying vec3 vColor;
-  varying float vAlpha;
-  varying float vSuit;
-  varying float vFaceDir;
-
-  mat3 rotateXYZ(vec3 angles) {
-    float cx = cos(angles.x); float sx = sin(angles.x);
-    float cy = cos(angles.y); float sy = sin(angles.y);
-    float cz = cos(angles.z); float sz = sin(angles.z);
-    return mat3(
-      cy*cz,              cy*sz,              -sy,
-      sx*sy*cz - cx*sz,   sx*sy*sz + cx*cz,   sx*cy,
-      cx*sy*cz + sx*sz,   cx*sy*sz - sx*cz,   cx*cy
-    );
-  }
-
-  void main() {
-    vUv = uv;
-    vSuit = aSuit;
-
-    // Per-card rotation: seed + time-based spin
-    vec3 angles = aRotation.xyz + uTime * aRotation.w;
-    mat3 rot = rotateXYZ(angles);
-
-    // Use the card's facing direction for front/back detection
-    vec3 faceNormal = rot * vec3(0.0, 0.0, 1.0);
-    vec3 viewDir = normalize(cameraPosition - aOffset);
-    vFaceDir = dot(faceNormal, viewDir);
-
-    vec3 pos = rot * (position * aSize) + aOffset;
-
-    vec3 baseColor = mix(aColor, uTintColor, uTintStrength);
-    vColor = baseColor;
-
-    // Distance fade
-    vec4 mvPos = modelViewMatrix * vec4(pos, 1.0);
-    float distFade = smoothstep(12.0, 6.0, -mvPos.z);
-    vAlpha = distFade * 0.7;
-
-    gl_Position = projectionMatrix * mvPos;
-  }
-`;
-
-const fragmentShader = /* glsl */ `
-  precision highp float;
-
-  varying vec2 vUv;
-  varying vec3 vColor;
-  varying float vAlpha;
-  varying float vSuit;
-  varying float vFaceDir;
-
-  // SDF for a rounded rectangle
-  float sdRoundedBox(vec2 p, vec2 b, float r) {
-    vec2 q = abs(p) - b + r;
-    return min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - r;
-  }
-
-  // Heart shape SDF
-  float sdHeart(vec2 p) {
-    p.y -= 0.3;
-    p.x = abs(p.x);
-    float a = atan(p.x, p.y) / 3.14159;
-    float r = length(p);
-    float h = clamp(a, 0.0, 1.0);
-    float d = r - 0.5 * (1.0 + h * 0.3);
-    return d;
-  }
-
-  // Diamond shape
-  float sdDiamond(vec2 p) {
-    p = abs(p);
-    return (p.x + p.y - 0.55) * 0.707;
-  }
-
-  // Club shape (3 circles + stem)
-  float sdClub(vec2 p) {
-    float d1 = length(p - vec2(-0.15, 0.1)) - 0.18;
-    float d2 = length(p - vec2(0.15, 0.1)) - 0.18;
-    float d3 = length(p - vec2(0.0, 0.3)) - 0.18;
-    float stem = sdRoundedBox(p - vec2(0.0, -0.1), vec2(0.05, 0.18), 0.02);
-    return min(min(d1, d2), min(d3, stem));
-  }
-
-  // Spade shape (inverted heart + stem)
-  float sdSpade(vec2 p) {
-    vec2 hp = vec2(p.x, -p.y + 0.55);
-    hp.x = abs(hp.x);
-    float a = atan(hp.x, hp.y) / 3.14159;
-    float r = length(hp);
-    float h = clamp(a, 0.0, 1.0);
-    float heart = r - 0.45 * (1.0 + h * 0.3);
-    float stem = sdRoundedBox(p - vec2(0.0, -0.1), vec2(0.04, 0.2), 0.02);
-    return min(heart, stem);
-  }
-
-  float getSuitSDF(vec2 p, float suit) {
-    if (suit < 0.5) return sdHeart(p);
-    if (suit < 1.5) return sdDiamond(p);
-    if (suit < 2.5) return sdClub(p);
-    return sdSpade(p);
-  }
-
-  void main() {
-    if (vAlpha < 0.01) discard;
-
-    // Map UV to centered coords
-    vec2 p = vUv * 2.0 - 1.0;
-
-    // Card body — rounded rectangle
-    float cardDist = sdRoundedBox(p, vec2(0.85, 0.85), 0.15);
-    float cardMask = 1.0 - smoothstep(-0.02, 0.02, cardDist);
-    if (cardMask < 0.01) discard;
-
-    // Determine if showing front or back
-    bool isFront = vFaceDir > 0.0;
-
-    vec3 col;
-    if (isFront) {
-      // White card face
-      col = vec3(0.95, 0.93, 0.90);
-
-      // Card border
-      float borderDist = sdRoundedBox(p, vec2(0.78, 0.78), 0.12);
-      float border = smoothstep(-0.02, 0.0, borderDist) * (1.0 - smoothstep(0.0, 0.02, borderDist));
-      col = mix(col, vec3(0.7, 0.65, 0.6), border * 0.5);
-
-      // Suit symbol in center
-      vec2 suitP = p * 1.5;
-      float suitDist = getSuitSDF(suitP, vSuit);
-      float suitMask = 1.0 - smoothstep(-0.02, 0.02, suitDist);
-
-      // Red for hearts/diamonds, dark for clubs/spades
-      vec3 suitColor = vSuit < 1.5 ? vec3(0.85, 0.1, 0.1) : vec3(0.12, 0.12, 0.12);
-      col = mix(col, suitColor, suitMask);
-
-      // Subtle tint from combat state
-      col = mix(col, vColor, 0.15);
-    } else {
-      // Card back — dark pattern with tint
-      col = mix(vec3(0.1, 0.22, 0.36), vColor, 0.3);
-
-      // Crosshatch pattern
-      float pattern = sin(p.x * 20.0) * sin(p.y * 20.0);
-      col += pattern * 0.06;
-
-      // Inner border
-      float innerDist = sdRoundedBox(p, vec2(0.72, 0.72), 0.1);
-      float innerBorder = smoothstep(-0.02, 0.0, innerDist) * (1.0 - smoothstep(0.0, 0.02, innerDist));
-      col += innerBorder * 0.15;
-    }
-
-    // Boost for bloom pickup
-    gl_FragColor = vec4(col * 1.5, cardMask * vAlpha);
-  }
-`;
 
 // Tint color targets
 const TINT_NONE = new THREE.Color('#4a8a5a');
@@ -271,8 +101,8 @@ export default function Particles({ combatState }: Props) {
     geo.setAttribute('aColor', new THREE.InstancedBufferAttribute(colorsArr, 3));
 
     const mat = new THREE.ShaderMaterial({
-      vertexShader,
-      fragmentShader,
+      vertexShader: cardsVertexShader,
+      fragmentShader: cardsFragmentShader,
       uniforms: {
         uTime: { value: 0 },
         uTintColor: { value: TINT_NONE.clone() },

--- a/src/background/burstEffects.ts
+++ b/src/background/burstEffects.ts
@@ -1,0 +1,143 @@
+import * as THREE from 'three';
+import type { EffectEvent } from './useCombatEffects';
+
+/**
+ * Burst-particle palette + per-event spawn dispatcher.
+ *
+ * `BurstParticles.tsx` owns the GPU buffer pool and the spawn primitive;
+ * this module owns the *what* — color constants, world-position lookup,
+ * and the `processEvent` switch that maps an EffectEvent to one or more
+ * `spawn(...)` calls. Pulled out so the .tsx file can stay focused on
+ * Three.js plumbing.
+ */
+
+// --- Palette ---
+export const C_GREEN = new THREE.Color('#66cc77');
+export const C_WHITE = new THREE.Color('#ffffff');
+export const C_RED = new THREE.Color('#ff4444');
+export const C_HEAL_GREEN = new THREE.Color('#44dd44');
+export const C_PURPLE = new THREE.Color('#aa44dd');
+export const C_GOLD = new THREE.Color('#d4a843');
+export const C_DARK_RED = new THREE.Color('#661111');
+export const C_ROYAL_PURPLE = new THREE.Color('#c8a2ff');
+export const C_ROYAL_GOLD = new THREE.Color('#ffd866');
+
+export function lerpColor(a: THREE.Color, b: THREE.Color, t: number): THREE.Color {
+  return new THREE.Color(
+    a.r + (b.r - a.r) * t,
+    a.g + (b.g - a.g) * t,
+    a.b + (b.b - a.b) * t,
+  );
+}
+
+// --- Spawn primitive contract ---
+//
+// Matches the signature of the `spawn()` function inside BurstParticles.tsx.
+// Defined here so the dispatcher is decoupled from the buffer-pool internals.
+export type SpawnFn = (
+  count: number,
+  x: number, y: number, z: number,
+  velFn: (i: number) => [number, number, number],
+  color: THREE.Color,
+  size: [number, number],
+  life: [number, number],
+  gravity?: number,
+  drag?: number,
+  colorVariant?: THREE.Color,
+) => void;
+
+export interface EffectContext {
+  spawn: SpawnFn;
+  /** Resolved hero portrait position in world coords. */
+  heroPos: [number, number];
+  /** Resolved monster portrait position in world coords. */
+  monsterPos: [number, number];
+}
+
+/**
+ * Dispatch an EffectEvent to spawn calls.
+ *
+ * Pure w.r.t. its inputs — given the same event + same spawn stub it
+ * makes the same calls. Easy to test by passing a vi.fn() spawn.
+ */
+export function processEvent(ev: EffectEvent, ctx: EffectContext): void {
+  const { spawn, heroPos, monsterPos } = ctx;
+  const [heroX, heroY] = heroPos;
+  const [monsterX, monsterY] = monsterPos;
+
+  const isVictory = ev.label === 'victory';
+  const isDefeat = ev.label === 'defeat';
+  const isCombo = ev.label?.startsWith('Combo');
+
+  if (isVictory) {
+    spawn(100, 0, 0, 0,
+      () => [(Math.random() - 0.5) * 0.5, (Math.random() - 0.5) * 0.5, (Math.random() - 0.5) * 0.2],
+      C_GOLD, [0.15, 0.35], [1.5, 3], -0.002, 0.97, C_WHITE);
+    return;
+  }
+  if (isDefeat) {
+    spawn(50, 0, 4, 0,
+      () => [(Math.random() - 0.5) * 0.3, -Math.random() * 0.15 - 0.05, (Math.random() - 0.5) * 0.1],
+      C_DARK_RED, [0.12, 0.25], [2, 4], 0.005, 0.99, C_RED);
+    return;
+  }
+
+  switch (ev.type) {
+    case 'hero-attack': {
+      const count = isCombo ? Math.min(60, 20 + ev.damage) : 30;
+      const intensity = isCombo ? 0.4 : 0.3;
+      spawn(count, monsterX, monsterY, 0,
+        () => [(Math.random() - 0.5) * intensity, Math.random() * 0.25 + 0.1, (Math.random() - 0.5) * 0.05],
+        C_GREEN, [0.1, 0.25], [0.8, 1.8], -0.003, 0.97, C_WHITE);
+      break;
+    }
+    case 'monster-attack': {
+      spawn(25, heroX, heroY, 0,
+        () => [(Math.random() - 0.5) * 0.2, -Math.random() * 0.2 - 0.08, (Math.random() - 0.5) * 0.05],
+        C_RED, [0.08, 0.18], [0.8, 1.5], 0.004, 0.98);
+      break;
+    }
+    case 'hero-heal': {
+      spawn(20, heroX, heroY, 0,
+        () => [(Math.random() - 0.5) * 0.1, Math.random() * 0.1 + 0.03, (Math.random() - 0.5) * 0.03],
+        C_HEAL_GREEN, [0.08, 0.15], [1, 2], -0.001, 0.99, C_WHITE);
+      break;
+    }
+    case 'poison': {
+      spawn(20, monsterX, monsterY, 0,
+        (i) => {
+          const angle = (i / 20) * Math.PI * 2;
+          return [Math.cos(angle) * 0.15, Math.sin(angle) * 0.15, (Math.random() - 0.5) * 0.03];
+        },
+        C_PURPLE, [0.1, 0.18], [0.8, 1.5], 0, 0.96);
+      break;
+    }
+    case 'empower': {
+      spawn(25, heroX, heroY, 0,
+        (i) => {
+          const angle = (i / 25) * Math.PI * 2;
+          return [Math.cos(angle) * 0.18, Math.sin(angle) * 0.18, 0];
+        },
+        C_GOLD, [0.1, 0.2], [0.8, 1.5], 0, 0.97, C_WHITE);
+      break;
+    }
+    case 'face-card': {
+      const isAwakens = ev.label?.includes('Awakens');
+      const isRises = ev.label?.includes('Rises');
+      const count = isAwakens ? 40 : isRises ? 25 : 15;
+      const speed = isAwakens ? 0.25 : isRises ? 0.18 : 0.1;
+      const baseColor = isAwakens ? C_ROYAL_GOLD : C_ROYAL_PURPLE;
+      const variantColor = isAwakens ? C_WHITE : C_ROYAL_GOLD;
+      const sizeRange: [number, number] = isAwakens ? [0.12, 0.3] : isRises ? [0.1, 0.22] : [0.06, 0.14];
+      const lifeRange: [number, number] = isAwakens ? [1.2, 2.5] : isRises ? [0.8, 1.8] : [0.6, 1.2];
+      spawn(count, heroX, heroY, 0,
+        (n) => {
+          const angle = (n / count) * Math.PI * 2 + Math.random() * 0.3;
+          const r = speed * (0.7 + Math.random() * 0.6);
+          return [Math.cos(angle) * r, Math.sin(angle) * r + 0.05, (Math.random() - 0.5) * 0.05];
+        },
+        baseColor, sizeRange, lifeRange, -0.001, 0.97, variantColor);
+      break;
+    }
+  }
+}

--- a/src/background/shaders/burst.ts
+++ b/src/background/shaders/burst.ts
@@ -1,0 +1,36 @@
+/**
+ * Vertex + fragment shaders for the combat-event burst particle system
+ * (`BurstParticles.tsx`). Each particle is a soft-edged circular point
+ * sprite. Color is multiplied by 2.5 in the fragment shader so the
+ * post-processing bloom pass picks it up as HDR-ish highlights.
+ */
+
+export const burstVertexShader = /* glsl */ `
+  precision highp float;
+  attribute float aAlpha;
+  attribute float aSize;
+  attribute vec3 aColor;
+  varying float vAlpha;
+  varying vec3 vColor;
+  void main() {
+    vAlpha = aAlpha;
+    vColor = aColor;
+    vec4 mvPos = modelViewMatrix * vec4(position, 1.0);
+    gl_Position = projectionMatrix * mvPos;
+    gl_PointSize = min(aSize * (800.0 / -mvPos.z), 64.0);
+  }
+`;
+
+export const burstFragmentShader = /* glsl */ `
+  precision highp float;
+  varying float vAlpha;
+  varying vec3 vColor;
+  void main() {
+    float dist = distance(gl_PointCoord, vec2(0.5));
+    float alpha = 1.0 - smoothstep(0.2, 0.5, dist);
+    alpha *= vAlpha;
+    if (alpha < 0.01) discard;
+    // Boost color above 1.0 for HDR bloom pickup
+    gl_FragColor = vec4(vColor * 2.5, alpha);
+  }
+`;

--- a/src/background/shaders/cards.ts
+++ b/src/background/shaders/cards.ts
@@ -1,0 +1,177 @@
+/**
+ * Vertex + fragment shaders for the ambient floating-card background
+ * (`Particles.tsx`). Each instance is a textured plane displaying a
+ * stylised playing card; the fragment shader computes the suit symbol
+ * via SDFs so no textures are needed.
+ */
+
+export const cardsVertexShader = /* glsl */ `
+  precision highp float;
+
+  attribute vec3 aOffset;      // world position of this card
+  attribute vec4 aRotation;    // xyz = euler seed, w = spin speed
+  attribute float aSize;       // scale multiplier
+  attribute float aSuit;       // 0-3 → suit type
+  attribute vec3 aColor;       // base tint per card
+
+  uniform float uTime;
+  uniform vec3 uTintColor;
+  uniform float uTintStrength;
+
+  varying vec2 vUv;
+  varying vec3 vColor;
+  varying float vAlpha;
+  varying float vSuit;
+  varying float vFaceDir;
+
+  mat3 rotateXYZ(vec3 angles) {
+    float cx = cos(angles.x); float sx = sin(angles.x);
+    float cy = cos(angles.y); float sy = sin(angles.y);
+    float cz = cos(angles.z); float sz = sin(angles.z);
+    return mat3(
+      cy*cz,              cy*sz,              -sy,
+      sx*sy*cz - cx*sz,   sx*sy*sz + cx*cz,   sx*cy,
+      cx*sy*cz + sx*sz,   cx*sy*sz - sx*cz,   cx*cy
+    );
+  }
+
+  void main() {
+    vUv = uv;
+    vSuit = aSuit;
+
+    // Per-card rotation: seed + time-based spin
+    vec3 angles = aRotation.xyz + uTime * aRotation.w;
+    mat3 rot = rotateXYZ(angles);
+
+    // Use the card's facing direction for front/back detection
+    vec3 faceNormal = rot * vec3(0.0, 0.0, 1.0);
+    vec3 viewDir = normalize(cameraPosition - aOffset);
+    vFaceDir = dot(faceNormal, viewDir);
+
+    vec3 pos = rot * (position * aSize) + aOffset;
+
+    vec3 baseColor = mix(aColor, uTintColor, uTintStrength);
+    vColor = baseColor;
+
+    // Distance fade
+    vec4 mvPos = modelViewMatrix * vec4(pos, 1.0);
+    float distFade = smoothstep(12.0, 6.0, -mvPos.z);
+    vAlpha = distFade * 0.7;
+
+    gl_Position = projectionMatrix * mvPos;
+  }
+`;
+
+export const cardsFragmentShader = /* glsl */ `
+  precision highp float;
+
+  varying vec2 vUv;
+  varying vec3 vColor;
+  varying float vAlpha;
+  varying float vSuit;
+  varying float vFaceDir;
+
+  // SDF for a rounded rectangle
+  float sdRoundedBox(vec2 p, vec2 b, float r) {
+    vec2 q = abs(p) - b + r;
+    return min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - r;
+  }
+
+  // Heart shape SDF
+  float sdHeart(vec2 p) {
+    p.y -= 0.3;
+    p.x = abs(p.x);
+    float a = atan(p.x, p.y) / 3.14159;
+    float r = length(p);
+    float h = clamp(a, 0.0, 1.0);
+    float d = r - 0.5 * (1.0 + h * 0.3);
+    return d;
+  }
+
+  // Diamond shape
+  float sdDiamond(vec2 p) {
+    p = abs(p);
+    return (p.x + p.y - 0.55) * 0.707;
+  }
+
+  // Club shape (3 circles + stem)
+  float sdClub(vec2 p) {
+    float d1 = length(p - vec2(-0.15, 0.1)) - 0.18;
+    float d2 = length(p - vec2(0.15, 0.1)) - 0.18;
+    float d3 = length(p - vec2(0.0, 0.3)) - 0.18;
+    float stem = sdRoundedBox(p - vec2(0.0, -0.1), vec2(0.05, 0.18), 0.02);
+    return min(min(d1, d2), min(d3, stem));
+  }
+
+  // Spade shape (inverted heart + stem)
+  float sdSpade(vec2 p) {
+    vec2 hp = vec2(p.x, -p.y + 0.55);
+    hp.x = abs(hp.x);
+    float a = atan(hp.x, hp.y) / 3.14159;
+    float r = length(hp);
+    float h = clamp(a, 0.0, 1.0);
+    float heart = r - 0.45 * (1.0 + h * 0.3);
+    float stem = sdRoundedBox(p - vec2(0.0, -0.1), vec2(0.04, 0.2), 0.02);
+    return min(heart, stem);
+  }
+
+  float getSuitSDF(vec2 p, float suit) {
+    if (suit < 0.5) return sdHeart(p);
+    if (suit < 1.5) return sdDiamond(p);
+    if (suit < 2.5) return sdClub(p);
+    return sdSpade(p);
+  }
+
+  void main() {
+    if (vAlpha < 0.01) discard;
+
+    // Map UV to centered coords
+    vec2 p = vUv * 2.0 - 1.0;
+
+    // Card body — rounded rectangle
+    float cardDist = sdRoundedBox(p, vec2(0.85, 0.85), 0.15);
+    float cardMask = 1.0 - smoothstep(-0.02, 0.02, cardDist);
+    if (cardMask < 0.01) discard;
+
+    // Determine if showing front or back
+    bool isFront = vFaceDir > 0.0;
+
+    vec3 col;
+    if (isFront) {
+      // White card face
+      col = vec3(0.95, 0.93, 0.90);
+
+      // Card border
+      float borderDist = sdRoundedBox(p, vec2(0.78, 0.78), 0.12);
+      float border = smoothstep(-0.02, 0.0, borderDist) * (1.0 - smoothstep(0.0, 0.02, borderDist));
+      col = mix(col, vec3(0.7, 0.65, 0.6), border * 0.5);
+
+      // Suit symbol in center
+      vec2 suitP = p * 1.5;
+      float suitDist = getSuitSDF(suitP, vSuit);
+      float suitMask = 1.0 - smoothstep(-0.02, 0.02, suitDist);
+
+      // Red for hearts/diamonds, dark for clubs/spades
+      vec3 suitColor = vSuit < 1.5 ? vec3(0.85, 0.1, 0.1) : vec3(0.12, 0.12, 0.12);
+      col = mix(col, suitColor, suitMask);
+
+      // Subtle tint from combat state
+      col = mix(col, vColor, 0.15);
+    } else {
+      // Card back — dark pattern with tint
+      col = mix(vec3(0.1, 0.22, 0.36), vColor, 0.3);
+
+      // Crosshatch pattern
+      float pattern = sin(p.x * 20.0) * sin(p.y * 20.0);
+      col += pattern * 0.06;
+
+      // Inner border
+      float innerDist = sdRoundedBox(p, vec2(0.72, 0.72), 0.1);
+      float innerBorder = smoothstep(-0.02, 0.0, innerDist) * (1.0 - smoothstep(0.0, 0.02, innerDist));
+      col += innerBorder * 0.15;
+    }
+
+    // Boost for bloom pickup
+    gl_FragColor = vec4(col * 1.5, cardMask * vAlpha);
+  }
+`;

--- a/src/combat/arena/models/DragonModel.tsx
+++ b/src/combat/arena/models/DragonModel.tsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
-import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
+import { useIdleAnimation } from './useIdleAnimation';
 
 export default function DragonModel() {
   const groupRef = useRef<THREE.Group>(null!);
@@ -8,23 +8,22 @@ export default function DragonModel() {
   const wingRRef = useRef<THREE.Mesh>(null!);
   const tailRef = useRef<THREE.Group>(null!);
 
-  useFrame(({ clock }) => {
-    const t = clock.elapsedTime;
-    // Breathing
-    groupRef.current.position.y = Math.sin(t * 1.0) * 0.04;
-    groupRef.current.rotation.z = Math.sin(t * 0.6) * 0.015;
-
-    // Wing flap
-    if (wingLRef.current && wingRRef.current) {
-      const flap = Math.sin(t * 1.5) * 0.2;
-      wingLRef.current.rotation.z = -0.6 + flap;
-      wingRRef.current.rotation.z = 0.6 - flap;
-    }
-
-    // Tail sway
-    if (tailRef.current) {
-      tailRef.current.rotation.y = Math.sin(t * 1.2) * 0.2;
-    }
+  // Note: original code overwrote position.y with sin(t)*0.04, ignoring
+  // the JSX `position={[0, -0.3, 0]}` initial. baseY: 0 preserves that.
+  useIdleAnimation(groupRef, {
+    baseY: 0,
+    breath: { rate: 1.0, amount: 0.04 },
+    sway: { rate: 0.6, amount: 0.015 },
+    extra: (t) => {
+      if (wingLRef.current && wingRRef.current) {
+        const flap = Math.sin(t * 1.5) * 0.2;
+        wingLRef.current.rotation.z = -0.6 + flap;
+        wingRRef.current.rotation.z = 0.6 - flap;
+      }
+      if (tailRef.current) {
+        tailRef.current.rotation.y = Math.sin(t * 1.2) * 0.2;
+      }
+    },
   });
 
   const bodyColor = '#8B2500';

--- a/src/combat/arena/models/GoblinModel.tsx
+++ b/src/combat/arena/models/GoblinModel.tsx
@@ -1,21 +1,20 @@
 import { useRef } from 'react';
-import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
+import { useIdleAnimation } from './useIdleAnimation';
 
 export default function GoblinModel() {
   const groupRef = useRef<THREE.Group>(null!);
   const daggerRef = useRef<THREE.Group>(null!);
 
-  useFrame(({ clock }) => {
-    const t = clock.elapsedTime;
-    // Idle sway
-    groupRef.current.rotation.z = Math.sin(t * 1.2) * 0.03;
-    groupRef.current.position.y = Math.sin(t * 2) * 0.03;
-
-    // Dagger menacing wave
-    if (daggerRef.current) {
-      daggerRef.current.rotation.z = Math.sin(t * 3) * 0.15 - 0.3;
-    }
+  useIdleAnimation(groupRef, {
+    baseY: 0,
+    breath: { rate: 2, amount: 0.03 },
+    sway: { rate: 1.2, amount: 0.03 },
+    extra: (t) => {
+      if (daggerRef.current) {
+        daggerRef.current.rotation.z = Math.sin(t * 3) * 0.15 - 0.3;
+      }
+    },
   });
 
   const green = '#5a8a3a';

--- a/src/combat/arena/models/KnightModel.tsx
+++ b/src/combat/arena/models/KnightModel.tsx
@@ -1,22 +1,20 @@
 import { useRef } from 'react';
-import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
+import { useIdleAnimation } from './useIdleAnimation';
 
 export default function KnightModel() {
   const groupRef = useRef<THREE.Group>(null!);
   const swordArmRef = useRef<THREE.Group>(null!);
 
-  useFrame(({ clock }) => {
-    const t = clock.elapsedTime;
-    // Gentle breathing
-    groupRef.current.position.y = -0.5 + Math.sin(t * 1.5) * 0.02;
-    // Subtle sway
-    groupRef.current.rotation.z = Math.sin(t * 1.0) * 0.015;
-
-    // Sword arm idle movement
-    if (swordArmRef.current) {
-      swordArmRef.current.rotation.z = 0.3 + Math.sin(t * 1.2) * 0.05;
-    }
+  useIdleAnimation(groupRef, {
+    baseY: -0.5,
+    breath: { rate: 1.5, amount: 0.02 },
+    sway: { rate: 1.0, amount: 0.015 },
+    extra: (t) => {
+      if (swordArmRef.current) {
+        swordArmRef.current.rotation.z = 0.3 + Math.sin(t * 1.2) * 0.05;
+      }
+    },
   });
 
   const armor = '#6a6a7a';

--- a/src/combat/arena/models/LichModel.tsx
+++ b/src/combat/arena/models/LichModel.tsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
-import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
+import { useIdleAnimation } from './useIdleAnimation';
 
 export default function LichModel() {
   const groupRef = useRef<THREE.Group>(null!);
@@ -8,23 +8,20 @@ export default function LichModel() {
   const eyeLRef = useRef<THREE.Mesh>(null!);
   const eyeRRef = useRef<THREE.Mesh>(null!);
 
-  useFrame(({ clock }) => {
-    const t = clock.elapsedTime;
-    // Hovering float
-    groupRef.current.position.y = Math.sin(t * 1.2) * 0.06;
-    groupRef.current.rotation.z = Math.sin(t * 0.7) * 0.02;
-
-    // Staff orb pulse
-    if (orbRef.current) {
-      const pulse = 0.5 + Math.sin(t * 2.5) * 0.3;
-      (orbRef.current.material as THREE.MeshStandardMaterial).emissiveIntensity = pulse;
-      orbRef.current.scale.setScalar(1 + Math.sin(t * 2.5) * 0.1);
-    }
-
-    // Eye flicker
-    const flicker = 0.6 + Math.sin(t * 4) * 0.3;
-    if (eyeLRef.current) (eyeLRef.current.material as THREE.MeshStandardMaterial).emissiveIntensity = flicker;
-    if (eyeRRef.current) (eyeRRef.current.material as THREE.MeshStandardMaterial).emissiveIntensity = flicker;
+  useIdleAnimation(groupRef, {
+    baseY: 0,
+    breath: { rate: 1.2, amount: 0.06 },
+    sway: { rate: 0.7, amount: 0.02 },
+    extra: (t) => {
+      if (orbRef.current) {
+        const pulse = 0.5 + Math.sin(t * 2.5) * 0.3;
+        (orbRef.current.material as THREE.MeshStandardMaterial).emissiveIntensity = pulse;
+        orbRef.current.scale.setScalar(1 + Math.sin(t * 2.5) * 0.1);
+      }
+      const flicker = 0.6 + Math.sin(t * 4) * 0.3;
+      if (eyeLRef.current) (eyeLRef.current.material as THREE.MeshStandardMaterial).emissiveIntensity = flicker;
+      if (eyeRRef.current) (eyeRRef.current.material as THREE.MeshStandardMaterial).emissiveIntensity = flicker;
+    },
   });
 
   const robe = '#3a1a5a';

--- a/src/combat/arena/models/SkeletonModel.tsx
+++ b/src/combat/arena/models/SkeletonModel.tsx
@@ -1,27 +1,24 @@
 import { useRef } from 'react';
-import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
+import { useIdleAnimation } from './useIdleAnimation';
 
 export default function SkeletonModel() {
   const groupRef = useRef<THREE.Group>(null!);
   const jawRef = useRef<THREE.Mesh>(null!);
   const swordRef = useRef<THREE.Group>(null!);
 
-  useFrame(({ clock }) => {
-    const t = clock.elapsedTime;
-    // Rattling idle sway
-    groupRef.current.rotation.z = Math.sin(t * 2.5) * 0.02;
-    groupRef.current.position.y = Math.sin(t * 3) * 0.015;
-
-    // Jaw chatter
-    if (jawRef.current) {
-      jawRef.current.position.y = -0.12 - Math.abs(Math.sin(t * 5)) * 0.03;
-    }
-
-    // Sword idle swing
-    if (swordRef.current) {
-      swordRef.current.rotation.z = Math.sin(t * 1.5) * 0.1 + 0.3;
-    }
+  useIdleAnimation(groupRef, {
+    baseY: 0,
+    breath: { rate: 3, amount: 0.015 },
+    sway: { rate: 2.5, amount: 0.02 },
+    extra: (t) => {
+      if (jawRef.current) {
+        jawRef.current.position.y = -0.12 - Math.abs(Math.sin(t * 5)) * 0.03;
+      }
+      if (swordRef.current) {
+        swordRef.current.rotation.z = Math.sin(t * 1.5) * 0.1 + 0.3;
+      }
+    },
   });
 
   const bone = '#e8e0d0';

--- a/src/combat/arena/models/WerewolfModel.tsx
+++ b/src/combat/arena/models/WerewolfModel.tsx
@@ -1,21 +1,21 @@
 import { useRef } from 'react';
-import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
+import { useIdleAnimation } from './useIdleAnimation';
 
 export default function WerewolfModel() {
   const groupRef = useRef<THREE.Group>(null!);
   const chestRef = useRef<THREE.Mesh>(null!);
 
-  useFrame(({ clock }) => {
-    const t = clock.elapsedTime;
-    // Heavy breathing
-    if (chestRef.current) {
-      const breathe = Math.sin(t * 1.8) * 0.04;
-      chestRef.current.scale.set(1 + breathe, 1 - breathe * 0.3, 1 + breathe * 0.5);
-    }
-    // Menacing sway
-    groupRef.current.rotation.z = Math.sin(t * 0.8) * 0.02;
-    groupRef.current.position.y = Math.sin(t * 1.6) * 0.02;
+  useIdleAnimation(groupRef, {
+    baseY: 0,
+    breath: { rate: 1.6, amount: 0.02 },
+    sway: { rate: 0.8, amount: 0.02 },
+    extra: (t) => {
+      if (chestRef.current) {
+        const breathe = Math.sin(t * 1.8) * 0.04;
+        chestRef.current.scale.set(1 + breathe, 1 - breathe * 0.3, 1 + breathe * 0.5);
+      }
+    },
   });
 
   const fur = '#4a4a5a';

--- a/src/combat/arena/models/useIdleAnimation.ts
+++ b/src/combat/arena/models/useIdleAnimation.ts
@@ -1,0 +1,47 @@
+import { useFrame } from '@react-three/fiber';
+import type { RefObject } from 'react';
+import * as THREE from 'three';
+
+export interface IdleAnimationConfig {
+  /** Base Y position the model rests at. */
+  baseY?: number;
+  /** Sine animation applied to position.y (breathing/floating). */
+  breath?: { rate: number; amount: number };
+  /** Sine animation applied to rotation.z (sway). */
+  sway?: { rate: number; amount: number };
+  /**
+   * Optional extra per-frame callback. Use this for monster-specific
+   * animation (wing flap, sword arm, jaw chatter, etc.) so each model
+   * file stays declarative for its idle parts.
+   */
+  extra?: (t: number) => void;
+}
+
+/**
+ * Shared idle-animation hook for combat arena models.
+ *
+ * Every monster model used to inline a near-identical `useFrame` block:
+ * a sine-based breath on `position.y` and a subtle sway on `rotation.z`,
+ * plus monster-specific extras. This hook centralizes the breath/sway
+ * boilerplate while letting each model pass its quirky bits via `extra`.
+ */
+export function useIdleAnimation(
+  groupRef: RefObject<THREE.Group>,
+  config: IdleAnimationConfig,
+) {
+  const baseY = config.baseY ?? 0;
+  useFrame(({ clock }) => {
+    const g = groupRef.current;
+    if (!g) return;
+    const t = clock.elapsedTime;
+    if (config.breath) {
+      g.position.y = baseY + Math.sin(t * config.breath.rate) * config.breath.amount;
+    } else {
+      g.position.y = baseY;
+    }
+    if (config.sway) {
+      g.rotation.z = Math.sin(t * config.sway.rate) * config.sway.amount;
+    }
+    config.extra?.(t);
+  });
+}

--- a/src/combat/sprites/DragonSprite.tsx
+++ b/src/combat/sprites/DragonSprite.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion';
+import PoisonDrips from './PoisonDrips';
 
 interface Props {
   poisoned: boolean;
@@ -51,29 +51,14 @@ export default function DragonSprite({ poisoned }: Props) {
       <line x1="38" y1="50" x2="40" y2="56" stroke="#cc4400" strokeWidth="1.5" strokeLinecap="round" />
       <line x1="42" y1="50" x2="46" y2="56" stroke="#cc4400" strokeWidth="1.5" strokeLinecap="round" />
 
-      {/* Poison drips when poisoned */}
-      {poisoned && (
-        <>
-          <motion.circle
-            cx="26" cy="48" r="2"
-            fill="#8a44bb"
-            animate={{ cy: [48, 56], opacity: [0.8, 0] }}
-            transition={{ duration: 1.2, repeat: Infinity, delay: 0 }}
-          />
-          <motion.circle
-            cx="38" cy="46" r="1.5"
-            fill="#aa55dd"
-            animate={{ cy: [46, 54], opacity: [0.7, 0] }}
-            transition={{ duration: 1, repeat: Infinity, delay: 0.4 }}
-          />
-          <motion.circle
-            cx="32" cy="50" r="1.8"
-            fill="#9944cc"
-            animate={{ cy: [50, 58], opacity: [0.8, 0] }}
-            transition={{ duration: 1.1, repeat: Infinity, delay: 0.8 }}
-          />
-        </>
-      )}
+      <PoisonDrips
+        poisoned={poisoned}
+        drips={[
+          { cx: 26, cy: 48, r: 2, duration: 1.2 },
+          { cx: 38, cy: 46, r: 1.5, duration: 1, opacity: 0.7 },
+          { cx: 32, cy: 50, r: 1.8, duration: 1.1 },
+        ]}
+      />
     </svg>
   );
 }

--- a/src/combat/sprites/GoblinSprite.tsx
+++ b/src/combat/sprites/GoblinSprite.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion';
+import PoisonDrips from './PoisonDrips';
 
 interface Props {
   poisoned: boolean;
@@ -42,16 +42,13 @@ export default function GoblinSprite({ poisoned }: Props) {
       <ellipse cx="26" cy="57" rx="4" ry="2" fill="#4a7a2a" />
       <ellipse cx="38" cy="57" rx="4" ry="2" fill="#4a7a2a" />
 
-      {poisoned && (
-        <>
-          <motion.circle cx="26" cy="50" r="2" fill="#8a44bb"
-            animate={{ cy: [50, 58], opacity: [0.8, 0] }}
-            transition={{ duration: 1.2, repeat: Infinity }} />
-          <motion.circle cx="38" cy="48" r="1.5" fill="#aa55dd"
-            animate={{ cy: [48, 56], opacity: [0.7, 0] }}
-            transition={{ duration: 1, repeat: Infinity, delay: 0.4 }} />
-        </>
-      )}
+      <PoisonDrips
+        poisoned={poisoned}
+        drips={[
+          { cx: 26, cy: 50, r: 2, duration: 1.2 },
+          { cx: 38, cy: 48, r: 1.5, duration: 1, opacity: 0.7 },
+        ]}
+      />
     </svg>
   );
 }

--- a/src/combat/sprites/LichSprite.tsx
+++ b/src/combat/sprites/LichSprite.tsx
@@ -1,4 +1,5 @@
 import { motion } from 'framer-motion';
+import PoisonDrips from './PoisonDrips';
 
 interface Props {
   poisoned: boolean;
@@ -41,16 +42,13 @@ export default function LichSprite({ poisoned }: Props) {
       <line x1="14" y1="44" x2="11" y2="45" stroke="#d0c8b8" strokeWidth="1" strokeLinecap="round" />
       <line x1="44" y1="38" x2="50" y2="34" stroke="#d0c8b8" strokeWidth="1.5" strokeLinecap="round" />
 
-      {poisoned && (
-        <>
-          <motion.circle cx="26" cy="52" r="2" fill="#8a44bb"
-            animate={{ cy: [52, 60], opacity: [0.8, 0] }}
-            transition={{ duration: 1.2, repeat: Infinity }} />
-          <motion.circle cx="38" cy="50" r="1.5" fill="#aa55dd"
-            animate={{ cy: [50, 58], opacity: [0.7, 0] }}
-            transition={{ duration: 1, repeat: Infinity, delay: 0.4 }} />
-        </>
-      )}
+      <PoisonDrips
+        poisoned={poisoned}
+        drips={[
+          { cx: 26, cy: 52, r: 2, duration: 1.2 },
+          { cx: 38, cy: 50, r: 1.5, duration: 1, opacity: 0.7 },
+        ]}
+      />
     </svg>
   );
 }

--- a/src/combat/sprites/PoisonDrips.tsx
+++ b/src/combat/sprites/PoisonDrips.tsx
@@ -1,0 +1,57 @@
+import { motion } from 'framer-motion';
+
+export interface DripConfig {
+  cx: number;
+  cy: number;
+  r: number;
+  /** Fall distance in viewBox units. Defaults to 8. */
+  fall?: number;
+  /** Animation duration in seconds. Defaults to 1.2. */
+  duration?: number;
+  /** Stagger delay in seconds. Defaults to drip index × 0.4. */
+  delay?: number;
+  /** Override fill color (default cycles purple). */
+  fill?: string;
+  /** Starting opacity (default 0.8). */
+  opacity?: number;
+}
+
+const DEFAULT_FILLS = ['#8a44bb', '#aa55dd', '#9944cc'];
+
+interface Props {
+  poisoned: boolean;
+  drips: DripConfig[];
+}
+
+/**
+ * Shared poison-drip animation used by every monster sprite. Each drip is
+ * a purple circle that falls and fades, looping forever. Per-monster the
+ * positions/sizes/timing differ slightly (the drips visually attach to the
+ * monster's body) — pass them via the `drips` prop. Renders nothing when
+ * `poisoned` is false.
+ */
+export default function PoisonDrips({ poisoned, drips }: Props) {
+  if (!poisoned) return null;
+  return (
+    <>
+      {drips.map((d, i) => {
+        const fall = d.fall ?? 8;
+        const duration = d.duration ?? 1.2;
+        const delay = d.delay ?? i * 0.4;
+        const fill = d.fill ?? DEFAULT_FILLS[i % DEFAULT_FILLS.length];
+        const opacity = d.opacity ?? 0.8;
+        return (
+          <motion.circle
+            key={i}
+            cx={d.cx}
+            cy={d.cy}
+            r={d.r}
+            fill={fill}
+            animate={{ cy: [d.cy, d.cy + fall], opacity: [opacity, 0] }}
+            transition={{ duration, repeat: Infinity, delay }}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/src/combat/sprites/SkeletonSprite.tsx
+++ b/src/combat/sprites/SkeletonSprite.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion';
+import PoisonDrips from './PoisonDrips';
 
 interface Props {
   poisoned: boolean;
@@ -46,16 +46,13 @@ export default function SkeletonSprite({ poisoned }: Props) {
       <line x1="32" y1="48" x2="24" y2="60" stroke="#d0c8b8" strokeWidth="2" strokeLinecap="round" />
       <line x1="32" y1="48" x2="40" y2="60" stroke="#d0c8b8" strokeWidth="2" strokeLinecap="round" />
 
-      {poisoned && (
-        <>
-          <motion.circle cx="26" cy="50" r="2" fill="#8a44bb"
-            animate={{ cy: [50, 58], opacity: [0.8, 0] }}
-            transition={{ duration: 1.2, repeat: Infinity }} />
-          <motion.circle cx="38" cy="48" r="1.5" fill="#aa55dd"
-            animate={{ cy: [48, 56], opacity: [0.7, 0] }}
-            transition={{ duration: 1, repeat: Infinity, delay: 0.4 }} />
-        </>
-      )}
+      <PoisonDrips
+        poisoned={poisoned}
+        drips={[
+          { cx: 26, cy: 50, r: 2, duration: 1.2 },
+          { cx: 38, cy: 48, r: 1.5, duration: 1, opacity: 0.7 },
+        ]}
+      />
     </svg>
   );
 }

--- a/src/combat/sprites/SlimeSprite.tsx
+++ b/src/combat/sprites/SlimeSprite.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion';
+import PoisonDrips from './PoisonDrips';
 
 interface Props {
   poisoned: boolean;
@@ -27,16 +27,13 @@ export default function SlimeSprite({ poisoned }: Props) {
       <ellipse cx="14" cy="54" rx="3" ry="2" fill="#44cc44" opacity="0.5" />
       <ellipse cx="50" cy="55" rx="2.5" ry="1.5" fill="#44cc44" opacity="0.4" />
 
-      {poisoned && (
-        <>
-          <motion.circle cx="24" cy="50" r="2" fill="#8a44bb"
-            animate={{ cy: [50, 58], opacity: [0.8, 0] }}
-            transition={{ duration: 1.2, repeat: Infinity }} />
-          <motion.circle cx="40" cy="48" r="1.5" fill="#aa55dd"
-            animate={{ cy: [48, 56], opacity: [0.7, 0] }}
-            transition={{ duration: 1, repeat: Infinity, delay: 0.4 }} />
-        </>
-      )}
+      <PoisonDrips
+        poisoned={poisoned}
+        drips={[
+          { cx: 24, cy: 50, r: 2, duration: 1.2 },
+          { cx: 40, cy: 48, r: 1.5, duration: 1, opacity: 0.7 },
+        ]}
+      />
     </svg>
   );
 }

--- a/src/combat/sprites/WerewolfSprite.tsx
+++ b/src/combat/sprites/WerewolfSprite.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion';
+import PoisonDrips from './PoisonDrips';
 
 interface Props {
   poisoned: boolean;
@@ -46,16 +46,13 @@ export default function WerewolfSprite({ poisoned }: Props) {
       {/* Tail */}
       <path d="M48 44 Q56 40 54 34" stroke="#4a4a5a" strokeWidth="3" fill="none" strokeLinecap="round" />
 
-      {poisoned && (
-        <>
-          <motion.circle cx="26" cy="50" r="2" fill="#8a44bb"
-            animate={{ cy: [50, 58], opacity: [0.8, 0] }}
-            transition={{ duration: 1.2, repeat: Infinity }} />
-          <motion.circle cx="38" cy="48" r="1.5" fill="#aa55dd"
-            animate={{ cy: [48, 56], opacity: [0.7, 0] }}
-            transition={{ duration: 1, repeat: Infinity, delay: 0.4 }} />
-        </>
-      )}
+      <PoisonDrips
+        poisoned={poisoned}
+        drips={[
+          { cx: 26, cy: 50, r: 2, duration: 1.2 },
+          { cx: 38, cy: 48, r: 1.5, duration: 1, opacity: 0.7 },
+        ]}
+      />
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
Phase 2 of the techdebt roadmap. Three duplication-cleanup issues bundled.

- **H3 (#35)** Add `useIdleAnimation` hook for the breath/sway loop every monster model used to inline. `Knight`/`Dragon`/`Werewolf`/`Skeleton`/`Goblin`/`Lich` now delegate the standard sin-based group animation and pass monster-specific bits (wing flap, jaw chatter, dagger wave, orb pulse, etc.) via an `extra` callback. `SlimeModel` is intentionally untouched — it animates a child mesh, not the group, so it doesn't fit the hook's contract.
  - Note: a full "ModelFactory" abstraction was considered but rejected — each monster's geometry is fundamentally different and pushing it into a data table would obscure rather than simplify. The repeated boilerplate is the `useFrame` block, and that's what the hook eliminates.
- **M2 (#38)** Add a shared `<PoisonDrips>` component for the purple falling-circle animation every monster sprite uses. All six sprites pass a small `drips` config (positions, sizes, durations) instead of inlining 8–12 lines of `motion.circle` each.
- **M3 (#39)** Extract `Particles.tsx` and `BurstParticles.tsx` GLSL shaders to `src/background/shaders/{cards,burst}.ts`. Pull the BurstParticles event dispatcher (color palette, `processEvent` switch, `lerpColor`) out to `src/background/burstEffects.ts`; the .tsx file now owns only the buffer pool, spawn primitive, and `useFrame` physics. `processEvent` is decoupled from Three.js plumbing — it just takes a `SpawnFn` and hero/monster world coords, so it could be unit-tested with a `vi.fn()` spawn stub.

No behavior changes. `BurstParticles.tsx` shrinks from 325 → ~190 LOC; `Particles.tsx` from 359 → ~190 LOC.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (bundle 1220 KiB vs 1221 KiB baseline — within noise)
- [x] `npm test` — 118 passed
- [ ] Manual smoke: load a run, confirm the floating-card background still renders + tints (hp low → red, poison → purple, empower → gold). Trigger combat events: hero attack (green burst from monster), monster attack (red burst from hero), hero heal (gentle green float), poison (purple spiral), empower (gold ring), face cards (Awakens=large gold, Rises=purple), victory (gold explosion), defeat (dark red sink). Confirm poison drips animate on every monster sprite when the player has poison stacks.

Closes #35, #38, #39.

https://claude.ai/code/session_012UqX4iVDjXAmufjvvgzbXa