### PR TITLE
Add gameStore and remaining detector unit tests

### DIFF
--- a/src/game/__tests__/store.test.ts
+++ b/src/game/__tests__/store.test.ts
@@ -1,0 +1,384 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useGameStore } from '../store';
+import { _withSuppressedEvents, useCombatStore } from '../combatStore';
+import type { Card, Rank, Suit } from '../types';
+
+function makeCard(suit: Suit, rank: Rank, faceUp = true): Card {
+  return { id: `${suit}-${rank}`, suit, rank, faceUp };
+}
+
+/**
+ * Apply a partial gameStore state without triggering combatStore events.
+ * Mirrors the helper used by combatStore.test.ts.
+ */
+function setup(partial: Partial<Parameters<typeof useGameStore.setState>[0]>) {
+  _withSuppressedEvents(() => {
+    useGameStore.setState(partial as Parameters<typeof useGameStore.setState>[0]);
+  });
+}
+
+function emptyTableau(): Card[][] {
+  return [[], [], [], [], [], [], []];
+}
+
+function emptyFoundations(): Card[][] {
+  return [[], [], [], []];
+}
+
+function resetAll() {
+  _withSuppressedEvents(() => {
+    useGameStore.getState().newGame();
+  });
+  useCombatStore.getState().resetCombat();
+}
+
+describe('gameStore', () => {
+  beforeEach(() => {
+    resetAll();
+  });
+
+  describe('newGame', () => {
+    it('deals 28 tableau cards across 7 columns', () => {
+      useGameStore.getState().newGame();
+      const state = useGameStore.getState();
+      const total = state.tableau.reduce((sum, p) => sum + p.length, 0);
+      expect(total).toBe(28);
+      expect(state.tableau.map(p => p.length)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    });
+
+    it('leaves 24 cards in stock and 0 in waste', () => {
+      useGameStore.getState().newGame();
+      const state = useGameStore.getState();
+      expect(state.stock.length).toBe(24);
+      expect(state.waste.length).toBe(0);
+    });
+
+    it('only the top card of each tableau column is face-up', () => {
+      useGameStore.getState().newGame();
+      const state = useGameStore.getState();
+      state.tableau.forEach(pile => {
+        if (pile.length === 0) return;
+        expect(pile[pile.length - 1].faceUp).toBe(true);
+        for (let i = 0; i < pile.length - 1; i++) {
+          expect(pile[i].faceUp).toBe(false);
+        }
+      });
+    });
+
+    it('clears foundations, undoStack, and isWon', () => {
+      setup({ isWon: true, undoStack: [{} as never] });
+      useGameStore.getState().newGame();
+      const state = useGameStore.getState();
+      expect(state.isWon).toBe(false);
+      expect(state.undoStack).toEqual([]);
+      expect(state.foundations).toEqual(emptyFoundations());
+    });
+
+    it('increments gameId', () => {
+      const before = useGameStore.getState().gameId;
+      useGameStore.getState().newGame();
+      expect(useGameStore.getState().gameId).toBe(before + 1);
+    });
+
+    it('honors a draw-mode override', () => {
+      useGameStore.getState().newGame(3);
+      expect(useGameStore.getState().drawMode).toBe(3);
+      useGameStore.getState().newGame(1);
+      expect(useGameStore.getState().drawMode).toBe(1);
+    });
+  });
+
+  describe('drawFromStock', () => {
+    it('moves drawMode cards from stock to waste face-up', () => {
+      setup({
+        stock: [makeCard('hearts', 5, false), makeCard('hearts', 6, false), makeCard('hearts', 7, false)],
+        waste: [],
+        drawMode: 1,
+      });
+      useGameStore.getState().drawFromStock();
+      const state = useGameStore.getState();
+      expect(state.stock.length).toBe(2);
+      expect(state.waste.length).toBe(1);
+      expect(state.waste[0]).toMatchObject({ suit: 'hearts', rank: 7, faceUp: true });
+    });
+
+    it('draws three cards in drawMode 3', () => {
+      setup({
+        stock: [
+          makeCard('hearts', 2, false),
+          makeCard('hearts', 3, false),
+          makeCard('hearts', 4, false),
+          makeCard('hearts', 5, false),
+        ],
+        waste: [],
+        drawMode: 3,
+      });
+      useGameStore.getState().drawFromStock();
+      const state = useGameStore.getState();
+      expect(state.stock.length).toBe(1);
+      expect(state.waste.length).toBe(3);
+      expect(state.waste.every(c => c.faceUp)).toBe(true);
+    });
+
+    it('draws fewer than drawMode when stock is short', () => {
+      setup({
+        stock: [makeCard('hearts', 2, false), makeCard('hearts', 3, false)],
+        waste: [],
+        drawMode: 3,
+      });
+      useGameStore.getState().drawFromStock();
+      const state = useGameStore.getState();
+      expect(state.stock.length).toBe(0);
+      expect(state.waste.length).toBe(2);
+    });
+
+    it('cycles waste back to stock face-down and increments stockCycleCount', () => {
+      setup({
+        stock: [],
+        waste: [makeCard('hearts', 2), makeCard('hearts', 3), makeCard('hearts', 4)],
+        stockCycleCount: 0,
+      });
+      useGameStore.getState().drawFromStock();
+      const state = useGameStore.getState();
+      expect(state.waste.length).toBe(0);
+      expect(state.stock.length).toBe(3);
+      expect(state.stock.every(c => !c.faceUp)).toBe(true);
+      // Stock is reversed waste
+      expect(state.stock[0].rank).toBe(4);
+      expect(state.stock[2].rank).toBe(2);
+      expect(state.stockCycleCount).toBe(1);
+    });
+
+    it('is a no-op when both stock and waste are empty', () => {
+      setup({ stock: [], waste: [], moves: 5 });
+      useGameStore.getState().drawFromStock();
+      expect(useGameStore.getState().moves).toBe(5);
+    });
+
+    it('increments moves and pushes a snapshot to undoStack', () => {
+      setup({
+        stock: [makeCard('hearts', 5, false)],
+        waste: [],
+        moves: 0,
+        undoStack: [],
+      });
+      useGameStore.getState().drawFromStock();
+      const state = useGameStore.getState();
+      expect(state.moves).toBe(1);
+      expect(state.undoStack.length).toBe(1);
+    });
+  });
+
+  describe('moveCards', () => {
+    it('moves a single card tableau → foundation when valid', () => {
+      setup({
+        tableau: [[makeCard('hearts', 1)], [], [], [], [], [], []],
+        foundations: emptyFoundations(),
+      });
+      useGameStore.getState().moveCards({
+        cards: [makeCard('hearts', 1)],
+        from: 'tableau-0',
+        fromIndex: 0,
+        to: 'foundation-0',
+      });
+      const state = useGameStore.getState();
+      expect(state.foundations[0]).toHaveLength(1);
+      expect(state.foundations[0][0].rank).toBe(1);
+      expect(state.tableau[0]).toEqual([]);
+    });
+
+    it('rejects an invalid foundation move', () => {
+      setup({
+        tableau: [[makeCard('hearts', 5)], [], [], [], [], [], []],
+        foundations: emptyFoundations(),
+      });
+      useGameStore.getState().moveCards({
+        cards: [makeCard('hearts', 5)],
+        from: 'tableau-0',
+        fromIndex: 0,
+        to: 'foundation-0',
+      });
+      // 5 of hearts cannot go to empty foundation (only Aces)
+      expect(useGameStore.getState().foundations[0]).toEqual([]);
+      expect(useGameStore.getState().tableau[0]).toHaveLength(1);
+    });
+
+    it('moves an alternating-color sequence tableau → tableau', () => {
+      setup({
+        tableau: [
+          [makeCard('hearts', 12), makeCard('clubs', 11)], // Q♥ J♣
+          [makeCard('spades', 13)],                         // K♠
+          [], [], [], [], [],
+        ],
+        foundations: emptyFoundations(),
+      });
+      useGameStore.getState().moveCards({
+        cards: [makeCard('hearts', 12), makeCard('clubs', 11)],
+        from: 'tableau-0',
+        fromIndex: 0,
+        to: 'tableau-1',
+      });
+      const state = useGameStore.getState();
+      expect(state.tableau[0]).toEqual([]);
+      expect(state.tableau[1]).toHaveLength(3);
+      expect(state.tableau[1].map(c => c.rank)).toEqual([13, 12, 11]);
+    });
+
+    it('rejects a same-color tableau move', () => {
+      setup({
+        tableau: [
+          [makeCard('hearts', 11)], // J♥
+          [makeCard('diamonds', 12)], // Q♦
+          [], [], [], [], [],
+        ],
+      });
+      useGameStore.getState().moveCards({
+        cards: [makeCard('hearts', 11)],
+        from: 'tableau-0',
+        fromIndex: 0,
+        to: 'tableau-1',
+      });
+      expect(useGameStore.getState().tableau[1]).toHaveLength(1);
+      expect(useGameStore.getState().tableau[0]).toHaveLength(1);
+    });
+
+    it('flips the newly exposed source-pile card face-up', () => {
+      setup({
+        tableau: [
+          [makeCard('clubs', 7, false), makeCard('hearts', 1)], // facedown 7♣ then A♥
+          [], [], [], [], [], [],
+        ],
+        foundations: emptyFoundations(),
+      });
+      useGameStore.getState().moveCards({
+        cards: [makeCard('hearts', 1)],
+        from: 'tableau-0',
+        fromIndex: 1,
+        to: 'foundation-0',
+      });
+      const state = useGameStore.getState();
+      expect(state.tableau[0]).toHaveLength(1);
+      expect(state.tableau[0][0].faceUp).toBe(true);
+    });
+
+    it('rejects multi-card moves to a foundation', () => {
+      setup({
+        tableau: [
+          [makeCard('hearts', 1), makeCard('clubs', 2)],
+          [], [], [], [], [], [],
+        ],
+        foundations: emptyFoundations(),
+      });
+      useGameStore.getState().moveCards({
+        cards: [makeCard('hearts', 1), makeCard('clubs', 2)],
+        from: 'tableau-0',
+        fromIndex: 0,
+        to: 'foundation-0',
+      });
+      // No move should happen
+      expect(useGameStore.getState().tableau[0]).toHaveLength(2);
+      expect(useGameStore.getState().foundations[0]).toEqual([]);
+    });
+
+    it('sets isWon when all 4 foundations reach 13', () => {
+      const fullFoundation = (suit: Suit) =>
+        Array.from({ length: 13 }, (_, i) => makeCard(suit, (i + 1) as Rank));
+      // 3 foundations already complete; final A→K just needs the King
+      const almostFullSpades = fullFoundation('spades').slice(0, 12);
+      setup({
+        foundations: [
+          fullFoundation('hearts'),
+          fullFoundation('diamonds'),
+          fullFoundation('clubs'),
+          almostFullSpades,
+        ],
+        tableau: [[makeCard('spades', 13)], [], [], [], [], [], []],
+      });
+      useGameStore.getState().moveCards({
+        cards: [makeCard('spades', 13)],
+        from: 'tableau-0',
+        fromIndex: 0,
+        to: 'foundation-3',
+      });
+      expect(useGameStore.getState().isWon).toBe(true);
+    });
+  });
+
+  describe('undo', () => {
+    it('restores the prior snapshot and clears isWon', () => {
+      setup({
+        tableau: [[makeCard('hearts', 1)], [], [], [], [], [], []],
+        foundations: emptyFoundations(),
+      });
+      useGameStore.getState().moveCards({
+        cards: [makeCard('hearts', 1)],
+        from: 'tableau-0',
+        fromIndex: 0,
+        to: 'foundation-0',
+      });
+      // Confirm move happened
+      expect(useGameStore.getState().foundations[0]).toHaveLength(1);
+
+      useGameStore.getState().undo();
+      const state = useGameStore.getState();
+      expect(state.foundations[0]).toEqual([]);
+      expect(state.tableau[0]).toHaveLength(1);
+      expect(state.isWon).toBe(false);
+    });
+
+    it('is a no-op when undoStack is empty', () => {
+      setup({
+        tableau: emptyTableau(),
+        undoStack: [],
+        moves: 0,
+      });
+      useGameStore.getState().undo();
+      expect(useGameStore.getState().moves).toBe(0);
+    });
+
+    it('caps undoStack at 50 snapshots', () => {
+      // Push 60 moves to verify the cap
+      setup({
+        stock: Array.from({ length: 60 }, (_, i) => makeCard('hearts', ((i % 13) + 1) as Rank, false)),
+        waste: [],
+        drawMode: 1,
+        undoStack: [],
+      });
+      for (let i = 0; i < 60; i++) {
+        useGameStore.getState().drawFromStock();
+      }
+      expect(useGameStore.getState().undoStack.length).toBe(50);
+    });
+  });
+
+  describe('autoComplete', () => {
+    it('moves one foundation-eligible top card per call', () => {
+      setup({
+        tableau: [
+          [makeCard('hearts', 1)],
+          [makeCard('clubs', 1)],
+          [], [], [], [], [],
+        ],
+        foundations: emptyFoundations(),
+      });
+      useGameStore.getState().autoComplete();
+      const state = useGameStore.getState();
+      // Exactly one Ace moved
+      const moved = state.foundations.flat().length;
+      expect(moved).toBe(1);
+    });
+
+    it('does nothing when no top cards are eligible', () => {
+      setup({
+        tableau: [
+          [makeCard('hearts', 5)],
+          [makeCard('clubs', 9)],
+          [], [], [], [], [],
+        ],
+        foundations: emptyFoundations(),
+      });
+      useGameStore.getState().autoComplete();
+      expect(useGameStore.getState().foundations.flat()).toEqual([]);
+    });
+  });
+});

--- a/src/game/combat/__tests__/moreDetectors.test.ts
+++ b/src/game/combat/__tests__/moreDetectors.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Card, Suit, Rank } from '../../types';
+import type { CombatActionsSlice, DetectorContext } from '../types';
+import { detectFaceCardMoves } from '../detectors/faceCardMoveDetector';
+import { detectReveals } from '../detectors/revealDetector';
+import { buildFaceCardPiles } from '../types';
+
+function makeCard(suit: Suit, rank: Rank, faceUp = true): Card {
+  return { id: `${suit}-${rank}`, suit, rank, faceUp };
+}
+
+function stubCombat(): CombatActionsSlice & { _calls: Record<string, unknown[][]> } {
+  const calls: Record<string, unknown[][]> = {};
+  const track = (name: string) =>
+    vi.fn((...args: unknown[]) => { (calls[name] ||= []).push(args); });
+  return {
+    dealDamageToMonster: track('dealDamageToMonster'),
+    dealDamageToHero: track('dealDamageToHero'),
+    healMonster: track('healMonster'),
+    healHero: track('healHero'),
+    applyPoison: track('applyPoison'),
+    setPoisonTurns: track('setPoisonTurns'),
+    setEmpowerMultiplier: track('setEmpowerMultiplier'),
+    emitFaceCardEvent: track('emitFaceCardEvent'),
+    _calls: calls,
+  } as ReturnType<typeof stubCombat>;
+}
+
+function makeCtx(overrides: Partial<{ heroHp: number }> = {}, triggered = new Set<string>()) {
+  const combat = stubCombat();
+  const setHeroHp = vi.fn();
+  const ctx: DetectorContext = {
+    combat,
+    combatState: () => ({
+      empowerMultiplier: 1.0,
+      poisonTurns: 0,
+      combatResult: 'none',
+      monsterAttackDamage: 12,
+      heroHp: overrides.heroHp ?? 50,
+    }),
+    setHeroHp,
+    playTriggeredCards: triggered,
+  };
+  return { ctx, combat, setHeroHp };
+}
+
+function emptyTab(): Card[][] {
+  return [[], [], [], [], [], [], []];
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// faceCardMoveDetector — tier-2 "Rises!" effects when a face card lands
+// at the bottom of a moved group on a new tableau column.
+// ──────────────────────────────────────────────────────────────────────
+describe('faceCardMoveDetector', () => {
+  function moveFaceCardToCol0(rank: Rank) {
+    const card = makeCard('hearts', rank);
+    const prevTab = emptyTab();
+    prevTab[1] = [card]; // started in column 1
+    const nextTab = emptyTab();
+    nextTab[0] = [card]; // moved to column 0
+
+    const prevPiles = buildFaceCardPiles({ tableau: prevTab, waste: [] });
+    const nextPiles = buildFaceCardPiles({ tableau: nextTab, waste: [] });
+    const prevLengths = prevTab.map(p => p.length);
+    return { card, prevTab, nextTab, prevPiles, nextPiles, prevLengths };
+  }
+
+  it('triggers Ace Rises! tier-2 on first move', () => {
+    const { nextTab, prevPiles, nextPiles, prevLengths } = moveFaceCardToCol0(1);
+    const { ctx, combat } = makeCtx();
+    detectFaceCardMoves(prevPiles, nextPiles, prevLengths, /*prevMoves*/ 0, { tableau: nextTab, waste: [], moves: 1 }, ctx);
+    expect(combat._calls.healHero?.[0]).toEqual([2]);
+    expect(combat._calls.emitFaceCardEvent?.[0]).toEqual(['Ace Rises!']);
+    expect(ctx.playTriggeredCards.has('hearts-1')).toBe(true);
+  });
+
+  it('triggers Jack Rises! (poison 2) tier-2', () => {
+    const { nextTab, prevPiles, nextPiles, prevLengths } = moveFaceCardToCol0(11);
+    const { ctx, combat } = makeCtx();
+    detectFaceCardMoves(prevPiles, nextPiles, prevLengths, 0, { tableau: nextTab, waste: [], moves: 1 }, ctx);
+    expect(combat._calls.setPoisonTurns?.[0]).toEqual([2]);
+    expect(combat._calls.emitFaceCardEvent?.[0]).toEqual(['Jack Rises!']);
+  });
+
+  it('triggers Queen Rises! (heal 3) tier-2', () => {
+    const { nextTab, prevPiles, nextPiles, prevLengths } = moveFaceCardToCol0(12);
+    const { ctx, combat } = makeCtx();
+    detectFaceCardMoves(prevPiles, nextPiles, prevLengths, 0, { tableau: nextTab, waste: [], moves: 1 }, ctx);
+    expect(combat._calls.healHero?.[0]).toEqual([3]);
+    expect(combat._calls.emitFaceCardEvent?.[0]).toEqual(['Queen Rises!']);
+  });
+
+  it('triggers King Rises! (empower 1.5) tier-2', () => {
+    const { nextTab, prevPiles, nextPiles, prevLengths } = moveFaceCardToCol0(13);
+    const { ctx, combat } = makeCtx();
+    detectFaceCardMoves(prevPiles, nextPiles, prevLengths, 0, { tableau: nextTab, waste: [], moves: 1 }, ctx);
+    expect(combat._calls.setEmpowerMultiplier?.[0]).toEqual([1.5]);
+    expect(combat._calls.emitFaceCardEvent?.[0]).toEqual(['King Rises!']);
+  });
+
+  it('does not re-trigger a card that already fired tier-2', () => {
+    const { nextTab, prevPiles, nextPiles, prevLengths } = moveFaceCardToCol0(12);
+    const triggered = new Set<string>(['hearts-12']);
+    const { ctx, combat } = makeCtx({}, triggered);
+    detectFaceCardMoves(prevPiles, nextPiles, prevLengths, 0, { tableau: nextTab, waste: [], moves: 1 }, ctx);
+    expect(combat._calls.healHero).toBeUndefined();
+    expect(combat._calls.emitFaceCardEvent).toBeUndefined();
+  });
+
+  it('reverses Queen tier-2 on undo (-3 hp)', () => {
+    // Card is currently back in col 1 (the "prev" of the original move),
+    // moves count went down → undo path.
+    const card = makeCard('hearts', 12);
+    const triggered = new Set<string>(['hearts-12']);
+    const tabBack = emptyTab();
+    tabBack[1] = [card];
+    const piles = buildFaceCardPiles({ tableau: tabBack, waste: [] });
+    // prevPiles claims card was in tableau-0 (where it had been pre-undo)
+    const prevPiles = new Map<string, string>([['hearts-12', 'tableau-0']]);
+
+    const { ctx, setHeroHp } = makeCtx({ heroHp: 20 }, triggered);
+    detectFaceCardMoves(prevPiles, piles, tabBack.map(p => p.length), /*prevMoves*/ 5, { tableau: tabBack, waste: [], moves: 4 }, ctx);
+    expect(setHeroHp).toHaveBeenCalledWith(17);
+    expect(triggered.has('hearts-12')).toBe(false);
+  });
+
+  it('reverses King tier-2 on undo (empower → 1.0)', () => {
+    const card = makeCard('hearts', 13);
+    const triggered = new Set<string>(['hearts-13']);
+    const tabBack = emptyTab();
+    tabBack[1] = [card];
+    const piles = buildFaceCardPiles({ tableau: tabBack, waste: [] });
+    const prevPiles = new Map<string, string>([['hearts-13', 'tableau-0']]);
+
+    const { ctx, combat } = makeCtx({}, triggered);
+    detectFaceCardMoves(prevPiles, piles, tabBack.map(p => p.length), 5, { tableau: tabBack, waste: [], moves: 4 }, ctx);
+    expect(combat._calls.setEmpowerMultiplier?.[0]).toEqual([1.0]);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// revealDetector — tier-1 "Stirs..." effects when a face-down card is
+// flipped face-up.
+// ──────────────────────────────────────────────────────────────────────
+describe('revealDetector', () => {
+  it('deals 2 damage per revealed card', () => {
+    const tab = emptyTab();
+    tab[0] = [makeCard('hearts', 5)]; // 1 face-up
+    const prevCounts = [1, 0, 0, 0, 0, 0, 0]; // was 1 face-down in col 0
+    const prevIds = new Set<string>(['hearts-5']); // (any id that's now face-up)
+    const { ctx, combat } = makeCtx();
+    detectReveals(prevCounts, prevIds, tab, ctx);
+    // Reveal damage: 2 × 1 = 2
+    expect(combat._calls.dealDamageToMonster?.[0]).toEqual([2, 'Reveal!']);
+  });
+
+  it('triggers Ace Stirs... tier-1 (heal 1)', () => {
+    const tab = emptyTab();
+    tab[0] = [makeCard('hearts', 1)];
+    const prevCounts = [1, 0, 0, 0, 0, 0, 0];
+    const prevIds = new Set<string>(['hearts-1']);
+    const { ctx, combat } = makeCtx();
+    detectReveals(prevCounts, prevIds, tab, ctx);
+    expect(combat._calls.healHero?.[0]).toEqual([1]);
+    expect(combat._calls.emitFaceCardEvent?.[0]).toEqual(['Ace Stirs...']);
+  });
+
+  it('triggers Jack/Queen/King Stirs... tier-1', () => {
+    for (const [rank, expected] of [
+      [11, ['Jack Stirs...', 'setPoisonTurns', 1]] as const,
+      [12, ['Queen Stirs...', 'healHero', 2]] as const,
+      [13, ['King Stirs...', 'setEmpowerMultiplier', 1.25]] as const,
+    ]) {
+      const tab = emptyTab();
+      tab[0] = [makeCard('hearts', rank as Rank)];
+      const prevCounts = [1, 0, 0, 0, 0, 0, 0];
+      const prevIds = new Set<string>([`hearts-${rank}`]);
+      const { ctx, combat } = makeCtx();
+      detectReveals(prevCounts, prevIds, tab, ctx);
+      const [label, action, value] = expected;
+      expect(combat._calls.emitFaceCardEvent?.[0]).toEqual([label]);
+      expect(combat._calls[action]?.[0]).toEqual([value]);
+    }
+  });
+
+  it('heals monster on un-reveal (undo)', () => {
+    const tab = emptyTab();
+    tab[0] = [makeCard('hearts', 5, false)]; // now face-down
+    const prevCounts = [0, 0, 0, 0, 0, 0, 0]; // had 0 face-down
+    const prevIds = new Set<string>(); // (none were face-down before)
+    const { ctx, combat } = makeCtx();
+    detectReveals(prevCounts, prevIds, tab, ctx);
+    expect(combat._calls.healMonster?.[0]).toEqual([2]);
+  });
+
+  it('reverses Ace tier-1 on un-reveal (-1 hp)', () => {
+    const tab = emptyTab();
+    tab[0] = [makeCard('hearts', 1, false)]; // Ace flipped back to face-down
+    const prevCounts = [0, 0, 0, 0, 0, 0, 0];
+    const prevIds = new Set<string>();
+    const { ctx, setHeroHp } = makeCtx({ heroHp: 30 });
+    detectReveals(prevCounts, prevIds, tab, ctx);
+    expect(setHeroHp).toHaveBeenCalledWith(29);
+  });
+});


### PR DESCRIPTION
## Summary
Closes the highest-ROI part of issue #42 — `gameStore` had no direct unit tests, and two combat detectors (`faceCardMoveDetector`, `revealDetector`) were never covered when the rest were extracted in #51.

**Scope (intentional):** store + detector tests only. Component / drag-drop / background tests are out of scope here — they'd require adding `jsdom` + React Testing Library and reconfiguring vitest's `environment: 'node'`. Worth filing as a follow-up if the coverage gap is still painful after this lands.

### Added

- **`src/game/__tests__/store.test.ts`** (24 tests)
  - `newGame`: 28-card deal across 7 columns, only top of each column face-up, foundations/undoStack/isWon cleared, gameId increments, drawMode override.
  - `drawFromStock`: single + drawMode-3 + short-stock; waste→stock cycle (face-down + reverse + `stockCycleCount` increment); empty no-op; moves + undoStack push.
  - `moveCards`: valid tableau→foundation, invalid foundation rejected, alternating-color tableau sequence, same-color rejection, source pile flips face-up after pop, multi-card foundation move rejected, `isWon` detection when all 4 foundations reach 13.
  - `undo`: restores snapshot + clears isWon, no-op on empty stack, 50-snapshot cap (verified by 60 draws).
  - `autoComplete`: moves one eligible top card per call, no-op when nothing eligible.

- **`src/game/combat/__tests__/moreDetectors.test.ts`** (12 tests)
  - `faceCardMoveDetector`: tier-2 "Rises!" forward path for Ace/Jack/Queen/King; dedup via `playTriggeredCards`; undo reverses Queen heal (-3 hp) and King empower (back to 1.0).
  - `revealDetector`: 2 dmg per revealed card; tier-1 "Stirs..." for all four ranks; heal monster on un-reveal; Ace tier-1 reversed on undo (-1 hp).

### Test plan
- [x] `npm run typecheck` clean
- [x] `npm test` — **154 passed** (was 118; +36)
- [x] No production-code changes — all combatStore.test.ts and dropPreview.test.ts cases still pass unchanged.

Closes #42.

https://claude.ai/code/session_012UqX4iVDjXAmufjvvgzbXa