### PR TITLE
Extract drop-target resolution from GameBoard (#40)

### DIFF
--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -6,7 +6,27 @@ import Tableau from './Tableau';
 import { useGameStore } from '../game/store';
 import { useResponsive } from '../hooks/useResponsive';
 import { useDragApi } from '../game/DragContext';
+import { resolveDropTarget, type Point } from './dropTarget';
 import './GameBoard.css';
+
+// DOM adapters for resolveDropTarget. Kept here so the helper itself stays
+// pure and unit-testable.
+function elementsAtPoint(point: Point): string[] {
+  const ids: string[] = [];
+  for (const el of document.elementsFromPoint(point.x, point.y)) {
+    const pileEl = (el as HTMLElement).closest('[data-pile-id]');
+    const id = pileEl?.getAttribute('data-pile-id');
+    if (id) ids.push(id);
+  }
+  return ids;
+}
+
+function getPileCenter(pileId: string): Point | null {
+  const el = document.querySelector(`[data-pile-id="${pileId}"]`);
+  if (!el) return null;
+  const rect = el.getBoundingClientRect();
+  return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+}
 
 export default function GameBoard() {
   const { cardWidth, cardHeight, gap, faceUpOffset } = useResponsive();
@@ -42,41 +62,14 @@ export default function GameBoard() {
     // Read fresh state from store (avoid stale closures)
     const state = useGameStore.getState();
 
-    // Find drop target via elementsFromPoint
-    const elements = document.elementsFromPoint(point.x, point.y);
-    let targetPileId: string | null = null;
-
-    for (const el of elements) {
-      const pileEl = (el as HTMLElement).closest('[data-pile-id]');
-      if (pileEl) {
-        const id = pileEl.getAttribute('data-pile-id');
-        if (id && id !== dragSource.pileId) {
-          targetPileId = id;
-          break;
-        }
-      }
-    }
-
-    // Fallback: if elementsFromPoint missed but we have valid targets,
-    // find the closest valid target pile to the pointer (within max snap distance)
-    if (!targetPileId && validTargets.size > 0) {
-      // Stock drags are very lenient — snap to waste from anywhere
-      const isStockDrag = dragSource.pileId === 'stock';
-      const MAX_SNAP_DISTANCE = isStockDrag ? Infinity : cardWidth * 1.2;
-      let bestDist = Infinity;
-      for (const vtId of validTargets) {
-        const el = document.querySelector(`[data-pile-id="${vtId}"]`);
-        if (!el) continue;
-        const rect = el.getBoundingClientRect();
-        const cx = rect.left + rect.width / 2;
-        const cy = rect.top + rect.height / 2;
-        const dist = Math.hypot(point.x - cx, point.y - cy);
-        if (dist < bestDist && dist <= MAX_SNAP_DISTANCE) {
-          bestDist = dist;
-          targetPileId = vtId;
-        }
-      }
-    }
+    const targetPileId = resolveDropTarget({
+      point,
+      dragSourcePileId: dragSource.pileId,
+      validTargets,
+      cardWidth,
+      elementsAtPoint,
+      getPileCenter,
+    });
 
     if (!targetPileId) return;
 

--- a/src/components/__tests__/dropTarget.test.ts
+++ b/src/components/__tests__/dropTarget.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getMaxSnapDistance,
+  findClosestValidTarget,
+  resolveDropTarget,
+} from '../dropTarget';
+
+describe('getMaxSnapDistance', () => {
+  it('returns Infinity for stock drags', () => {
+    expect(getMaxSnapDistance(true, 80)).toBe(Infinity);
+  });
+  it('returns 1.2 * cardWidth for non-stock drags', () => {
+    expect(getMaxSnapDistance(false, 80)).toBeCloseTo(96);
+  });
+});
+
+describe('findClosestValidTarget', () => {
+  const rects: Record<string, { x: number; y: number }> = {
+    'tableau-0': { x: 0, y: 0 },
+    'tableau-1': { x: 100, y: 0 },
+    'foundation-0': { x: 500, y: 500 },
+  };
+  const getPileCenter = (id: string) => rects[id] ?? null;
+
+  it('returns the closest valid target within snap distance', () => {
+    const valid = new Set(['tableau-0', 'tableau-1']);
+    expect(findClosestValidTarget({ x: 90, y: 5 }, valid, 50, getPileCenter)).toBe(
+      'tableau-1',
+    );
+  });
+
+  it('returns null when no targets are within snap distance', () => {
+    const valid = new Set(['foundation-0']);
+    expect(findClosestValidTarget({ x: 0, y: 0 }, valid, 50, getPileCenter)).toBeNull();
+  });
+
+  it('skips piles whose center cannot be found', () => {
+    const valid = new Set(['tableau-0', 'missing']);
+    expect(findClosestValidTarget({ x: 0, y: 0 }, valid, 10, getPileCenter)).toBe(
+      'tableau-0',
+    );
+  });
+
+  it('returns null for empty target set', () => {
+    expect(findClosestValidTarget({ x: 0, y: 0 }, new Set(), 100, getPileCenter)).toBeNull();
+  });
+});
+
+describe('resolveDropTarget', () => {
+  const center = (id: string) => {
+    const map: Record<string, { x: number; y: number }> = {
+      'tableau-1': { x: 100, y: 0 },
+      'waste': { x: 200, y: 0 },
+    };
+    return map[id] ?? null;
+  };
+
+  it('uses elementsAtPoint when a pile is hit and is not the source', () => {
+    const target = resolveDropTarget({
+      point: { x: 0, y: 0 },
+      dragSourcePileId: 'tableau-0',
+      validTargets: new Set(),
+      cardWidth: 80,
+      elementsAtPoint: () => ['tableau-1'],
+      getPileCenter: center,
+    });
+    expect(target).toBe('tableau-1');
+  });
+
+  it('ignores the source pile from elementsAtPoint and falls through', () => {
+    const target = resolveDropTarget({
+      point: { x: 100, y: 0 },
+      dragSourcePileId: 'tableau-0',
+      validTargets: new Set(['tableau-1']),
+      cardWidth: 80,
+      elementsAtPoint: () => ['tableau-0'],
+      getPileCenter: center,
+    });
+    expect(target).toBe('tableau-1');
+  });
+
+  it('falls back to closest-valid when elementsAtPoint returns nothing', () => {
+    const target = resolveDropTarget({
+      point: { x: 110, y: 0 },
+      dragSourcePileId: 'tableau-0',
+      validTargets: new Set(['tableau-1']),
+      cardWidth: 80,
+      elementsAtPoint: () => [],
+      getPileCenter: center,
+    });
+    expect(target).toBe('tableau-1');
+  });
+
+  it('snaps stock drags to waste from arbitrary distance', () => {
+    const target = resolveDropTarget({
+      point: { x: 9999, y: 9999 },
+      dragSourcePileId: 'stock',
+      validTargets: new Set(['waste']),
+      cardWidth: 80,
+      elementsAtPoint: () => [],
+      getPileCenter: center,
+    });
+    expect(target).toBe('waste');
+  });
+
+  it('returns null when nothing matches', () => {
+    const target = resolveDropTarget({
+      point: { x: 0, y: 0 },
+      dragSourcePileId: 'tableau-0',
+      validTargets: new Set(),
+      cardWidth: 80,
+      elementsAtPoint: () => [],
+      getPileCenter: center,
+    });
+    expect(target).toBeNull();
+  });
+});

--- a/src/components/dropTarget.ts
+++ b/src/components/dropTarget.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure helpers for resolving the drop-target pile during a drag-end.
+ *
+ * Extracted from GameBoard so the snap/fallback logic can be unit-tested
+ * without a real DOM. The DOM-touching wiring lives in `domDropTarget.ts`.
+ */
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/** Maximum pointer-to-pile-center distance allowed for snap fallback. */
+export function getMaxSnapDistance(isStockDrag: boolean, cardWidth: number): number {
+  // Stock drags are very lenient — snap to waste from anywhere.
+  return isStockDrag ? Infinity : cardWidth * 1.2;
+}
+
+/**
+ * Among `validTargets`, return the id whose center is closest to `point`,
+ * provided it lies within `maxDistance`. Returns null otherwise.
+ */
+export function findClosestValidTarget(
+  point: Point,
+  validTargets: ReadonlySet<string>,
+  maxDistance: number,
+  getPileCenter: (pileId: string) => Point | null,
+): string | null {
+  let best: string | null = null;
+  let bestDist = Infinity;
+  for (const id of validTargets) {
+    const center = getPileCenter(id);
+    if (!center) continue;
+    const dist = Math.hypot(point.x - center.x, point.y - center.y);
+    if (dist < bestDist && dist <= maxDistance) {
+      bestDist = dist;
+      best = id;
+    }
+  }
+  return best;
+}
+
+export interface ResolveDropTargetArgs {
+  point: Point;
+  dragSourcePileId: string;
+  validTargets: ReadonlySet<string>;
+  cardWidth: number;
+  /** Pile ids found under the pointer, ordered topmost-first. */
+  elementsAtPoint: (point: Point) => string[];
+  getPileCenter: (pileId: string) => Point | null;
+}
+
+/**
+ * Resolve the pile id that a drag-end at `point` should drop into.
+ *
+ * Strategy:
+ *   1. Use the pile under the pointer (excluding the source pile).
+ *   2. Otherwise, snap to the closest valid target within range.
+ */
+export function resolveDropTarget(args: ResolveDropTargetArgs): string | null {
+  const { point, dragSourcePileId, validTargets, cardWidth, elementsAtPoint, getPileCenter } =
+    args;
+
+  for (const id of elementsAtPoint(point)) {
+    if (id && id !== dragSourcePileId) return id;
+  }
+
+  if (validTargets.size === 0) return null;
+  const maxDistance = getMaxSnapDistance(dragSourcePileId === 'stock', cardWidth);
+  return findClosestValidTarget(point, validTargets, maxDistance, getPileCenter);
+}


### PR DESCRIPTION
Closes #40.

Pulls the `elementsFromPoint` walk and closest-valid-target snap fallback out of `GameBoard`'s drag-end handler into a pure helper in `src/components/dropTarget.ts`. The helper takes `elementsAtPoint` / `getPileCenter` callbacks so it can be unit-tested without a DOM; `GameBoard` keeps thin adapters that wrap `document.elementsFromPoint` and `getBoundingClientRect`.

- New `getMaxSnapDistance`, `findClosestValidTarget`, `resolveDropTarget` (all pure).
- 11 unit tests in `src/components/__tests__/dropTarget.test.ts` (TDD).
- Existing 154 tests still pass; typecheck + build green.