### PR TITLE
Split Tableau component by concern (#41)

### DIFF
--- a/src/components/Tableau.tsx
+++ b/src/components/Tableau.tsx
@@ -1,11 +1,9 @@
 import { useRef, useCallback, useState } from 'react';
-import Card, { CardPlaceholder } from './Card';
 import { useGameStore } from '../game/store';
 import { findFoundationIndex, canMoveToTableau } from '../game/rules';
-import { FACE_DOWN_OFFSET } from '../utils/constants';
 import { useDropTargetValidation } from '../hooks/useDropTargetValidation';
 import type { PileId } from '../game/types';
-import DropPreview from './DropPreview';
+import TableauVisual from './TableauVisual';
 
 interface TableauProps {
   index: number;
@@ -16,6 +14,11 @@ interface TableauProps {
   onDragEnd?: (clientPoint: { x: number; y: number }) => void;
 }
 
+/**
+ * Tableau owns the per-pile drag state (zIndex boosting, follower transform
+ * tracking) and delegates rendering to TableauVisual. The drop-target
+ * validation predicate lives in useDropTargetValidation.
+ */
 export default function Tableau({
   index,
   cardWidth,
@@ -39,139 +42,103 @@ export default function Tableau({
     return canMoveToTableau([...drag.cards], pile);
   });
 
-  const handleDoubleClick = (cardIndex: number) => {
-    if (cardIndex !== pile.length - 1) return;
-    const card = pile[cardIndex];
-    if (!card.faceUp) return;
-    const fi = findFoundationIndex(card, foundations);
-    if (fi >= 0) {
-      moveCards({
-        cards: [card],
-        from: pileId,
-        fromIndex: cardIndex,
-        to: `foundation-${fi}` as PileId,
-      });
-    }
-  };
-
-  const handleLocalDragStart = useCallback((i: number) => {
-    dragIdxRef.current = i;
-    setIsDragSource(true);
-
-    // Boost zIndex on drag source and all follower wrappers
-    const container = containerRef.current;
-    if (container) {
-      container.querySelectorAll<HTMLElement>('[data-card-index]').forEach(el => {
-        const idx = parseInt(el.getAttribute('data-card-index')!);
-        if (idx >= i) {
-          el.style.zIndex = `${1000 + idx}`;
-        }
-      });
-    }
-    onDragStart?.(pileId, i);
-  }, [pileId, onDragStart]);
-
-  const handleDrag = useCallback((_event: PointerEvent, info: { offset: { x: number; y: number } }) => {
-    if (dragIdxRef.current === null) return;
-    const container = containerRef.current;
-    if (!container) return;
-
-    container.querySelectorAll<HTMLElement>('[data-card-index]').forEach(el => {
-      const idx = parseInt(el.getAttribute('data-card-index')!);
-      if (idx > dragIdxRef.current!) {
-        el.style.transform = `translate(${info.offset.x}px, ${info.offset.y}px)`;
-        el.style.transition = 'none';
+  const handleDoubleClick = useCallback(
+    (cardIndex: number) => {
+      if (cardIndex !== pile.length - 1) return;
+      const card = pile[cardIndex];
+      if (!card.faceUp) return;
+      const fi = findFoundationIndex(card, foundations);
+      if (fi >= 0) {
+        moveCards({
+          cards: [card],
+          from: pileId,
+          fromIndex: cardIndex,
+          to: `foundation-${fi}` as PileId,
+        });
       }
-    });
-  }, []);
+    },
+    [pile, foundations, moveCards, pileId],
+  );
 
-  const handleLocalDragEnd = useCallback((info: { event: PointerEvent }) => {
-    const container = containerRef.current;
-    if (container && dragIdxRef.current !== null) {
+  const handleLocalDragStart = useCallback(
+    (i: number) => {
+      dragIdxRef.current = i;
+      setIsDragSource(true);
+
+      // Boost zIndex on drag source and all follower wrappers
+      const container = containerRef.current;
+      if (container) {
+        container.querySelectorAll<HTMLElement>('[data-card-index]').forEach(el => {
+          const idx = parseInt(el.getAttribute('data-card-index')!);
+          if (idx >= i) {
+            el.style.zIndex = `${1000 + idx}`;
+          }
+        });
+      }
+      onDragStart?.(pileId, i);
+    },
+    [pileId, onDragStart],
+  );
+
+  const handleDrag = useCallback(
+    (_event: PointerEvent, info: { offset: { x: number; y: number } }) => {
+      if (dragIdxRef.current === null) return;
+      const container = containerRef.current;
+      if (!container) return;
+
       container.querySelectorAll<HTMLElement>('[data-card-index]').forEach(el => {
         const idx = parseInt(el.getAttribute('data-card-index')!);
-        if (idx >= dragIdxRef.current!) {
-          // Animate followers back to origin (matches dragSnapToOrigin)
-          if (idx > dragIdxRef.current!) {
-            el.style.transition = 'transform 0.5s cubic-bezier(0.22, 1, 0.36, 1)';
-            el.style.transform = '';
-          }
-          // Defer zIndex reset until after snap-back animation completes,
-          // otherwise cards render behind face-down cards during animation
-          setTimeout(() => {
-            el.style.transition = '';
-            el.style.zIndex = `${idx}`;
-          }, 500);
+        if (idx > dragIdxRef.current!) {
+          el.style.transform = `translate(${info.offset.x}px, ${info.offset.y}px)`;
+          el.style.transition = 'none';
         }
       });
-    }
-    dragIdxRef.current = null;
-    setIsDragSource(false);
-    onDragEnd?.({ x: info.event.clientX, y: info.event.clientY });
-  }, [onDragEnd]);
+    },
+    [],
+  );
 
-  // Calculate total height for the pile container
-  let totalOffset = 0;
-  for (let i = 0; i < pile.length; i++) {
-    if (i > 0) {
-      totalOffset += pile[i - 1].faceUp ? faceUpOffset : FACE_DOWN_OFFSET;
-    }
-  }
+  const handleLocalDragEnd = useCallback(
+    (info: { event: PointerEvent }) => {
+      const container = containerRef.current;
+      if (container && dragIdxRef.current !== null) {
+        container.querySelectorAll<HTMLElement>('[data-card-index]').forEach(el => {
+          const idx = parseInt(el.getAttribute('data-card-index')!);
+          if (idx >= dragIdxRef.current!) {
+            // Animate followers back to origin (matches dragSnapToOrigin)
+            if (idx > dragIdxRef.current!) {
+              el.style.transition = 'transform 0.5s cubic-bezier(0.22, 1, 0.36, 1)';
+              el.style.transform = '';
+            }
+            // Defer zIndex reset until after snap-back animation completes,
+            // otherwise cards render behind face-down cards during animation
+            setTimeout(() => {
+              el.style.transition = '';
+              el.style.zIndex = `${idx}`;
+            }, 500);
+          }
+        });
+      }
+      dragIdxRef.current = null;
+      setIsDragSource(false);
+      onDragEnd?.({ x: info.event.clientX, y: info.event.clientY });
+    },
+    [onDragEnd],
+  );
 
   return (
-    <div
+    <TableauVisual
       ref={containerRef}
-      data-pile-id={pileId}
-      style={{
-        position: 'relative',
-        width: cardWidth,
-        height: pile.length === 0 ? cardHeight : totalOffset + cardHeight,
-        minHeight: cardHeight,
-        zIndex: isDragSource ? 1000 : undefined,
-      }}
-    >
-      {pile.length === 0 && (
-        <>
-          {isValidTarget && <DropPreview targetPileId={pileId} />}
-          <CardPlaceholder width={cardWidth} height={cardHeight} label="K" />
-        </>
-      )}
-      {pile.map((card, i) => {
-        let top = 0;
-        for (let j = 0; j < i; j++) {
-          top += pile[j].faceUp ? faceUpOffset : FACE_DOWN_OFFSET;
-        }
-
-        const isTopCard = i === pile.length - 1;
-
-        return (
-          <div
-            key={card.id}
-            data-card-index={i}
-            className={isTopCard && isValidTarget ? 'valid-drop-target' : undefined}
-            style={{
-              position: 'absolute',
-              top,
-              left: 0,
-              zIndex: i,
-              width: cardWidth,
-              height: cardHeight,
-            }}
-          >
-            {isTopCard && isValidTarget && <DropPreview targetPileId={pileId} />}
-            <Card
-              card={card}
-              width={cardWidth}
-              height={cardHeight}
-              onDoubleClick={() => handleDoubleClick(i)}
-              draggable={card.faceUp}
-              onDragStart={() => handleLocalDragStart(i)}
-              onDrag={card.faceUp ? handleDrag : undefined}
-              onDragEnd={(info) => handleLocalDragEnd(info)}
-            />
-          </div>
-        );
-      })}
-    </div>
+      pileId={pileId}
+      pile={pile}
+      cardWidth={cardWidth}
+      cardHeight={cardHeight}
+      faceUpOffset={faceUpOffset}
+      isDragSource={isDragSource}
+      isValidTarget={isValidTarget}
+      onCardDoubleClick={handleDoubleClick}
+      onCardDragStart={handleLocalDragStart}
+      onCardDrag={handleDrag}
+      onCardDragEnd={handleLocalDragEnd}
+    />
   );
 }

--- a/src/components/TableauVisual.tsx
+++ b/src/components/TableauVisual.tsx
@@ -1,0 +1,96 @@
+import { forwardRef } from 'react';
+import Card, { CardPlaceholder } from './Card';
+import DropPreview from './DropPreview';
+import { computePileLayout } from './tableauLayout';
+import { FACE_DOWN_OFFSET } from '../utils/constants';
+import type { Card as CardType, PileId } from '../game/types';
+
+interface TableauVisualProps {
+  pileId: PileId;
+  pile: ReadonlyArray<CardType>;
+  cardWidth: number;
+  cardHeight: number;
+  faceUpOffset: number;
+  isDragSource: boolean;
+  isValidTarget: boolean;
+  onCardDoubleClick: (cardIndex: number) => void;
+  onCardDragStart: (cardIndex: number) => void;
+  onCardDrag?: (event: PointerEvent, info: { offset: { x: number; y: number } }) => void;
+  onCardDragEnd: (info: { event: PointerEvent }) => void;
+}
+
+/**
+ * Pure presentational rendering of a tableau pile. Drag/zIndex state lives
+ * in the parent — this component only consumes it via props.
+ */
+const TableauVisual = forwardRef<HTMLDivElement, TableauVisualProps>(function TableauVisual(
+  {
+    pileId,
+    pile,
+    cardWidth,
+    cardHeight,
+    faceUpOffset,
+    isDragSource,
+    isValidTarget,
+    onCardDoubleClick,
+    onCardDragStart,
+    onCardDrag,
+    onCardDragEnd,
+  },
+  ref,
+) {
+  const { tops, totalOffset } = computePileLayout(pile, faceUpOffset, FACE_DOWN_OFFSET);
+
+  return (
+    <div
+      ref={ref}
+      data-pile-id={pileId}
+      style={{
+        position: 'relative',
+        width: cardWidth,
+        height: pile.length === 0 ? cardHeight : totalOffset + cardHeight,
+        minHeight: cardHeight,
+        zIndex: isDragSource ? 1000 : undefined,
+      }}
+    >
+      {pile.length === 0 && (
+        <>
+          {isValidTarget && <DropPreview targetPileId={pileId} />}
+          <CardPlaceholder width={cardWidth} height={cardHeight} label="K" />
+        </>
+      )}
+      {pile.map((card, i) => {
+        const isTopCard = i === pile.length - 1;
+        return (
+          <div
+            key={card.id}
+            data-card-index={i}
+            className={isTopCard && isValidTarget ? 'valid-drop-target' : undefined}
+            style={{
+              position: 'absolute',
+              top: tops[i],
+              left: 0,
+              zIndex: i,
+              width: cardWidth,
+              height: cardHeight,
+            }}
+          >
+            {isTopCard && isValidTarget && <DropPreview targetPileId={pileId} />}
+            <Card
+              card={card}
+              width={cardWidth}
+              height={cardHeight}
+              onDoubleClick={() => onCardDoubleClick(i)}
+              draggable={card.faceUp}
+              onDragStart={() => onCardDragStart(i)}
+              onDrag={card.faceUp ? onCardDrag : undefined}
+              onDragEnd={onCardDragEnd}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+});
+
+export default TableauVisual;

--- a/src/components/__tests__/tableauLayout.test.ts
+++ b/src/components/__tests__/tableauLayout.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { computePileLayout } from '../tableauLayout';
+import type { Card } from '../../game/types';
+
+const card = (id: string, faceUp: boolean): Card => ({
+  id,
+  rank: 1,
+  suit: 'spades',
+  faceUp,
+});
+
+describe('computePileLayout', () => {
+  const FACE_UP = 30;
+  const FACE_DOWN = 8; // matches FACE_DOWN_OFFSET in constants
+
+  it('returns zero offsets and zero total for empty pile', () => {
+    expect(computePileLayout([], FACE_UP, FACE_DOWN)).toEqual({
+      tops: [],
+      totalOffset: 0,
+    });
+  });
+
+  it('places the first card at top 0', () => {
+    const layout = computePileLayout([card('1', true)], FACE_UP, FACE_DOWN);
+    expect(layout.tops).toEqual([0]);
+    expect(layout.totalOffset).toBe(0);
+  });
+
+  it('uses face-up offset between two face-up cards', () => {
+    const layout = computePileLayout(
+      [card('1', true), card('2', true)],
+      FACE_UP,
+      FACE_DOWN,
+    );
+    expect(layout.tops).toEqual([0, FACE_UP]);
+    expect(layout.totalOffset).toBe(FACE_UP);
+  });
+
+  it('uses face-down offset for face-down predecessors', () => {
+    const layout = computePileLayout(
+      [card('1', false), card('2', false), card('3', true)],
+      FACE_UP,
+      FACE_DOWN,
+    );
+    expect(layout.tops).toEqual([0, FACE_DOWN, FACE_DOWN * 2]);
+    expect(layout.totalOffset).toBe(FACE_DOWN * 2);
+  });
+
+  it('mixes offsets according to each predecessor face state', () => {
+    const layout = computePileLayout(
+      [card('1', false), card('2', true), card('3', true)],
+      FACE_UP,
+      FACE_DOWN,
+    );
+    expect(layout.tops).toEqual([0, FACE_DOWN, FACE_DOWN + FACE_UP]);
+    expect(layout.totalOffset).toBe(FACE_DOWN + FACE_UP);
+  });
+});

--- a/src/components/tableauLayout.ts
+++ b/src/components/tableauLayout.ts
@@ -1,0 +1,28 @@
+import type { Card } from '../game/types';
+
+export interface PileLayout {
+  /** Pixel `top` offset for each card in the pile, parallel to the input. */
+  tops: number[];
+  /** Total stacking offset of the last card (height = totalOffset + cardHeight). */
+  totalOffset: number;
+}
+
+/**
+ * Compute the vertical layout of a tableau pile. Pure so it can be unit
+ * tested without rendering.
+ */
+export function computePileLayout(
+  pile: ReadonlyArray<Card>,
+  faceUpOffset: number,
+  faceDownOffset: number,
+): PileLayout {
+  const tops: number[] = [];
+  let acc = 0;
+  for (let i = 0; i < pile.length; i++) {
+    if (i > 0) {
+      acc += pile[i - 1].faceUp ? faceUpOffset : faceDownOffset;
+    }
+    tops.push(acc);
+  }
+  return { tops, totalOffset: acc };
+}


### PR DESCRIPTION
Closes #41.

- New `TableauVisual` presentational subcomponent: pure JSX, takes pile + drag/target flags as props, owns no state.
- New `tableauLayout.ts` with `computePileLayout` (face-up/face-down stacking math), unit-tested in isolation (5 new tests, TDD).
- `Tableau` becomes the drag/zIndex/double-click coordinator and forwards rendering to `TableauVisual`. Validator hook (`useDropTargetValidation`) was already extracted in M1.

170 tests pass; build green.