### PR TITLE
Introduce orchestration layer to decouple stores (#34)

### DIFF
--- a/src/game/__tests__/orchestrator.test.ts
+++ b/src/game/__tests__/orchestrator.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useGameStore } from '../store';
+import { useCombatStore } from '../combatStore';
+import { useMetaStore } from '../metaStore';
+import {
+  startEncounter,
+  endRunEffects,
+  _withSuppressedEvents,
+} from '../orchestrator';
+import type { EncounterConfig } from '../combatStore';
+
+const config: EncounterConfig = {
+  monsterName: 'TestMon',
+  monsterId: 'goblin',
+  monsterMaxHp: 30,
+  monsterAttackDamage: 5,
+  heroMaxHp: 40,
+};
+
+beforeEach(() => {
+  // Restore default meta state
+  useMetaStore.setState({
+    gold: 0,
+    totalGold: 0,
+    totalMonstersSlain: 0,
+    totalRunsCompleted: 0,
+    totalRunsStarted: 0,
+  });
+});
+
+describe('startEncounter', () => {
+  it('resets the deck via gameStore.newGame and starts combat with the given config', () => {
+    const gameIdBefore = useGameStore.getState().gameId;
+    startEncounter(config);
+    const game = useGameStore.getState();
+    const combat = useCombatStore.getState();
+
+    expect(game.gameId).not.toBe(gameIdBefore);
+    expect(combat.monsterName).toBe('TestMon');
+    expect(combat.monsterMaxHp).toBe(30);
+    expect(combat.heroMaxHp).toBe(40);
+    expect(combat.isActive).toBe(true);
+  });
+
+  it('does not fire combat events while seeding the deck', () => {
+    startEncounter(config);
+    const eventIdAfterStart = useCombatStore.getState().eventId;
+    // newGame should have run under suppression — eventId should be 0.
+    expect(eventIdAfterStart).toBe(0);
+  });
+});
+
+describe('endRunEffects', () => {
+  it('credits gold and records a completed run on victory', () => {
+    endRunEffects(42, 'victory');
+    const meta = useMetaStore.getState();
+    expect(meta.gold).toBeGreaterThanOrEqual(42);
+    expect(meta.totalRunsCompleted).toBe(1);
+  });
+
+  it('credits gold but does not record a completed run on defeat', () => {
+    endRunEffects(7, 'defeat');
+    const meta = useMetaStore.getState();
+    expect(meta.gold).toBeGreaterThanOrEqual(7);
+    expect(meta.totalRunsCompleted).toBe(0);
+  });
+});
+
+describe('_withSuppressedEvents', () => {
+  it('runs the body without firing combat events', () => {
+    startEncounter(config);
+    const before = useCombatStore.getState().eventId;
+    _withSuppressedEvents(() => {
+      useGameStore.getState().newGame();
+    });
+    expect(useCombatStore.getState().eventId).toBe(before);
+  });
+});

--- a/src/game/combatStore.ts
+++ b/src/game/combatStore.ts
@@ -1,6 +1,4 @@
 import { create } from 'zustand';
-import { useGameStore } from './store';
-import { EventDetector } from './combat/EventDetector';
 
 export interface EncounterConfig {
   monsterName: string;
@@ -165,56 +163,8 @@ export const useCombatStore = create<CombatState & CombatActions>()((set, get) =
   },
 }));
 
-// --- Event detection ---
-// All per-frame change detection lives in EventDetector. The store keeps
-// only the actions that mutate combat state.
-const detector = new EventDetector(useGameStore.getState(), {
-  combat: {
-    dealDamageToMonster: (d, l) => useCombatStore.getState().dealDamageToMonster(d, l),
-    dealDamageToHero: (d) => useCombatStore.getState().dealDamageToHero(d),
-    healMonster: (a) => useCombatStore.getState().healMonster(a),
-    healHero: (a, l) => useCombatStore.getState().healHero(a, l),
-    applyPoison: () => useCombatStore.getState().applyPoison(),
-    setPoisonTurns: (t) => useCombatStore.getState().setPoisonTurns(t),
-    setEmpowerMultiplier: (m) => useCombatStore.getState().setEmpowerMultiplier(m),
-    emitFaceCardEvent: (l) => useCombatStore.getState().emitFaceCardEvent(l),
-  },
-  combatState: () => {
-    const s = useCombatStore.getState();
-    return {
-      empowerMultiplier: s.empowerMultiplier,
-      poisonTurns: s.poisonTurns,
-      combatResult: s.combatResult,
-      monsterAttackDamage: s.monsterAttackDamage,
-      heroHp: s.heroHp,
-    };
-  },
-  setHeroHp: (hp) => useCombatStore.setState({ heroHp: hp }),
-  isCombatPaused: () => {
-    const c = useCombatStore.getState();
-    return !c.isActive || c.combatResult !== 'none';
-  },
-});
-
-useGameStore.subscribe((state) => detector.run(state));
-
-// --- Public helpers ---
-//
-// `hasPlayTriggered` is a real public API: dropPreview.ts reads it to
-// suppress duplicate "Rises!" hints when a face card has already fired
-// its tier-2 effect. The other two are test-only utilities for setting
-// up gameStore state without firing combat events.
-
-export function hasPlayTriggered(cardId: string): boolean {
-  return detector.hasPlayTriggered(cardId);
-}
-
-/** @internal — used by tests to reset tracking state between cases. */
-export function _resetTracking(): void {
-  detector.withSuppressedEvents(() => {}, () => useGameStore.getState());
-}
-
-/** @internal — used by tests to apply gameStore state without events. */
-export function _withSuppressedEvents(fn: () => void): void {
-  detector.withSuppressedEvents(fn, () => useGameStore.getState());
-}
+// Cross-store wiring (event detection + run orchestration) lives in
+// `./orchestrator`. combatStore now exposes only its own state and actions
+// — see issue #34. The helpers below are re-exports kept for backward
+// compatibility with tests and dropPreview.ts.
+export { hasPlayTriggered, _resetTracking, _withSuppressedEvents } from './orchestrator';

--- a/src/game/orchestrator.ts
+++ b/src/game/orchestrator.ts
@@ -1,0 +1,111 @@
+/**
+ * Cross-store orchestration layer.
+ *
+ * Stores expose data + intra-store actions only. The orchestrator owns
+ * every cross-store side effect, breaking the App→runStore→combatStore→
+ * gameStore reach-through chain that the tech-debt issue (#34) called out.
+ *
+ * Dependency graph after this refactor:
+ *
+ *     orchestrator ──► gameStore
+ *           │                  ▲
+ *           ├──► combatStore   │ (via EventDetector subscription)
+ *           ├──► runStore      │
+ *           └──► metaStore     │
+ *
+ * No store imports another store for side effects. `runStore` actions
+ * delegate cross-store work to `startEncounter` / `endRunEffects` here.
+ */
+
+import { useGameStore } from './store';
+import { useCombatStore, type EncounterConfig } from './combatStore';
+import { useMetaStore } from './metaStore';
+import { EventDetector } from './combat/EventDetector';
+
+// --- Combat event detection ----------------------------------------------
+
+const detector = new EventDetector(useGameStore.getState(), {
+  combat: {
+    dealDamageToMonster: (d, l) => useCombatStore.getState().dealDamageToMonster(d, l),
+    dealDamageToHero: (d) => useCombatStore.getState().dealDamageToHero(d),
+    healMonster: (a) => useCombatStore.getState().healMonster(a),
+    healHero: (a, l) => useCombatStore.getState().healHero(a, l),
+    applyPoison: () => useCombatStore.getState().applyPoison(),
+    setPoisonTurns: (t) => useCombatStore.getState().setPoisonTurns(t),
+    setEmpowerMultiplier: (m) => useCombatStore.getState().setEmpowerMultiplier(m),
+    emitFaceCardEvent: (l) => useCombatStore.getState().emitFaceCardEvent(l),
+  },
+  combatState: () => {
+    const s = useCombatStore.getState();
+    return {
+      empowerMultiplier: s.empowerMultiplier,
+      poisonTurns: s.poisonTurns,
+      combatResult: s.combatResult,
+      monsterAttackDamage: s.monsterAttackDamage,
+      heroHp: s.heroHp,
+    };
+  },
+  setHeroHp: (hp) => useCombatStore.setState({ heroHp: hp }),
+  isCombatPaused: () => {
+    const c = useCombatStore.getState();
+    return !c.isActive || c.combatResult !== 'none';
+  },
+});
+
+useGameStore.subscribe((state) => detector.run(state));
+
+// --- Public helpers reading detector state -------------------------------
+
+export function hasPlayTriggered(cardId: string): boolean {
+  return detector.hasPlayTriggered(cardId);
+}
+
+/** @internal — used by tests to reset tracking state between cases. */
+export function _resetTracking(): void {
+  detector.withSuppressedEvents(() => {}, () => useGameStore.getState());
+}
+
+/** @internal — used by tests and the orchestrator itself to apply
+ *  gameStore state without firing combat events. */
+export function _withSuppressedEvents(fn: () => void): void {
+  detector.withSuppressedEvents(fn, () => useGameStore.getState());
+}
+
+// --- Run-level orchestration ---------------------------------------------
+
+/**
+ * Begin a new encounter: deal a fresh deck (without firing combat events)
+ * and start combat with the given monster config.
+ */
+export function startEncounter(config: EncounterConfig): void {
+  _withSuppressedEvents(() => {
+    useGameStore.getState().newGame();
+  });
+  useCombatStore.getState().startCombat(config);
+}
+
+/** Record run-start meta progression. */
+export function recordRunStarted(): void {
+  useMetaStore.getState().recordRunStarted();
+}
+
+/** Record monster-slain meta progression. */
+export function recordMonsterSlain(): void {
+  useMetaStore.getState().recordMonsterSlain();
+}
+
+/**
+ * Apply end-of-run side effects: credit gold and (on victory) record
+ * the completed run.
+ */
+export function endRunEffects(goldEarned: number, result: 'victory' | 'defeat'): void {
+  useMetaStore.getState().addGold(goldEarned);
+  if (result === 'victory') {
+    useMetaStore.getState().recordRunCompleted();
+  }
+}
+
+/** Read the hero's current HP — used by runStore to compute carry-over and gold. */
+export function getHeroHp(): number {
+  return useCombatStore.getState().heroHp;
+}

--- a/src/game/runStore.ts
+++ b/src/game/runStore.ts
@@ -1,9 +1,13 @@
 import { create } from 'zustand';
 import { type Difficulty, DIFFICULTY_CONFIG } from './difficulty';
 import { type MonsterDef, MONSTER_ROSTER, buildEncounterConfig } from '../combat/monsters';
-import { useCombatStore, _withSuppressedEvents } from './combatStore';
-import { useGameStore } from './store';
-import { useMetaStore } from './metaStore';
+import {
+  startEncounter,
+  endRunEffects,
+  recordRunStarted,
+  recordMonsterSlain,
+  getHeroHp,
+} from './orchestrator';
 
 interface RunState {
   isRunActive: boolean;
@@ -60,12 +64,8 @@ export const useRunStore = create<RunState & RunActions>()((set, get) => ({
       runResult: 'none',
     });
 
-    _withSuppressedEvents(() => {
-      useGameStore.getState().newGame();
-    });
-    useCombatStore.getState().startCombat(config);
-
-    useMetaStore.getState().recordRunStarted();
+    startEncounter(config);
+    recordRunStarted();
   },
 
   advanceEncounter: () => {
@@ -73,11 +73,11 @@ export const useRunStore = create<RunState & RunActions>()((set, get) => ({
     const { difficulty, encounters, currentEncounterIndex, heroMaxHp } = state;
 
     // Calculate gold for defeated monster
-    const heroHp = useCombatStore.getState().heroHp;
+    const heroHp = getHeroHp();
     const gold = calculateGold(encounters[currentEncounterIndex], difficulty, heroHp, heroMaxHp);
     const newGoldEarned = state.goldEarned + gold;
 
-    useMetaStore.getState().recordMonsterSlain();
+    recordMonsterSlain();
 
     const nextIndex = currentEncounterIndex + 1;
 
@@ -102,18 +102,12 @@ export const useRunStore = create<RunState & RunActions>()((set, get) => ({
       lastGoldAwarded: gold,
     });
 
-    _withSuppressedEvents(() => {
-      useGameStore.getState().newGame();
-    });
-    useCombatStore.getState().startCombat(config);
+    startEncounter(config);
   },
 
   endRun: (result: 'victory' | 'defeat') => {
     const state = get();
-    useMetaStore.getState().addGold(state.goldEarned);
-    if (result === 'victory') {
-      useMetaStore.getState().recordRunCompleted();
-    }
+    endRunEffects(state.goldEarned, result);
     set({
       isRunActive: false,
       runResult: result,


### PR DESCRIPTION
Closes #34.

Stores now expose state and intra-store actions only. A new `src/game/orchestrator.ts` owns every cross-store side effect:

- The `EventDetector` subscription that translates `gameStore` changes into `combatStore` actions (moved out of `combatStore.ts`).
- `startEncounter` / `endRunEffects` / `record*` helpers consumed by `runStore` actions.

After this change:
- `combatStore` no longer imports `useGameStore`.
- `runStore` no longer imports `useCombatStore`, `useGameStore`, or `useMetaStore` directly.
- Dependency graph: `orchestrator → {gameStore, combatStore, runStore, metaStore}`. No store imports another for side effects.

Backward-compat re-exports of `hasPlayTriggered` / `_withSuppressedEvents` / `_resetTracking` from `combatStore` keep `dropPreview.ts` and existing tests working without churn.

New `orchestrator.test.ts` (TDD) covers `startEncounter`, `endRunEffects` (victory + defeat), and event suppression. 175 tests pass; build green.