### PR TITLE
Quality cleanup: pileId helper + Particles double-init + drop compat re-exports

### DIFF
--- a/src/background/Particles.tsx
+++ b/src/background/Particles.tsx
@@ -25,7 +25,7 @@ interface Props {
 export default function Particles({ combatState }: Props) {
   const meshRef = useRef<THREE.InstancedMesh>(null);
 
-  const { velocities, offsets, rotations } = useMemo(() => {
+  const { velocities, offsets, rotations, sizes, suits, colors } = useMemo(() => {
     const offsets = new Float32Array(CARD_COUNT * 3);
     const velocities = new Float32Array(CARD_COUNT * 3);
     const rotations = new Float32Array(CARD_COUNT * 4);
@@ -78,27 +78,9 @@ export default function Particles({ combatState }: Props) {
     // Add instanced attributes
     geo.setAttribute('aOffset', new THREE.InstancedBufferAttribute(offsets, 3));
     geo.setAttribute('aRotation', new THREE.InstancedBufferAttribute(rotations, 4));
-
-    const sizesArr = new Float32Array(CARD_COUNT);
-    const suitsArr = new Float32Array(CARD_COUNT);
-    const colorsArr = new Float32Array(CARD_COUNT * 3);
-    const baseColor = new THREE.Color('#4a8a5a');
-    const hsl = { h: 0, s: 0, l: 0 };
-    baseColor.getHSL(hsl);
-
-    for (let i = 0; i < CARD_COUNT; i++) {
-      sizesArr[i] = 0.5 + Math.random() * 0.8;
-      suitsArr[i] = Math.floor(Math.random() * 4);
-      const c = new THREE.Color();
-      c.setHSL(hsl.h + (Math.random() - 0.5) * 0.1, hsl.s, hsl.l + (Math.random() - 0.5) * 0.1);
-      colorsArr[i * 3] = c.r;
-      colorsArr[i * 3 + 1] = c.g;
-      colorsArr[i * 3 + 2] = c.b;
-    }
-
-    geo.setAttribute('aSize', new THREE.InstancedBufferAttribute(sizesArr, 1));
-    geo.setAttribute('aSuit', new THREE.InstancedBufferAttribute(suitsArr, 1));
-    geo.setAttribute('aColor', new THREE.InstancedBufferAttribute(colorsArr, 3));
+    geo.setAttribute('aSize', new THREE.InstancedBufferAttribute(sizes, 1));
+    geo.setAttribute('aSuit', new THREE.InstancedBufferAttribute(suits, 1));
+    geo.setAttribute('aColor', new THREE.InstancedBufferAttribute(colors, 3));
 
     const mat = new THREE.ShaderMaterial({
       vertexShader: cardsVertexShader,
@@ -115,7 +97,7 @@ export default function Particles({ combatState }: Props) {
     });
 
     return { geometry: geo, material: mat };
-  }, [offsets, rotations]);
+  }, [offsets, rotations, sizes, suits, colors]);
 
   const targetTint = useMemo(() => TINT_NONE.clone(), []);
 

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -6,6 +6,8 @@ import Tableau from './Tableau';
 import { useGameStore } from '../game/store';
 import { useResponsive } from '../hooks/useResponsive';
 import { useDragApi } from '../game/DragContext';
+import { parsePileId } from '../game/pileId';
+import type { PileId } from '../game/types';
 import { resolveDropTarget, type Point } from './dropTarget';
 import './GameBoard.css';
 
@@ -38,14 +40,14 @@ export default function GameBoard() {
     dragSourceRef.current = { pileId, cardIndex };
 
     const state = useGameStore.getState();
+    const parsed = parsePileId(pileId);
     let cards: import('../game/types').Card[] = [];
-    if (pileId === 'stock') {
+    if (parsed?.kind === 'stock') {
       cards = state.stock.length > 0 ? [state.stock[state.stock.length - 1]] : [];
-    } else if (pileId === 'waste') {
+    } else if (parsed?.kind === 'waste') {
       cards = state.waste.length > 0 ? [state.waste[state.waste.length - 1]] : [];
-    } else if (pileId.startsWith('tableau-')) {
-      const tabIdx = parseInt(pileId.split('-')[1]);
-      cards = state.tableau[tabIdx].slice(cardIndex);
+    } else if (parsed?.kind === 'tableau') {
+      cards = state.tableau[parsed.index].slice(cardIndex);
     }
     dragApi.start(cards, pileId);
   }, [dragApi]);
@@ -80,22 +82,20 @@ export default function GameBoard() {
     }
 
     // Get the cards being moved from fresh state
-    let movingCards: import('../game/types').Card[];
-    if (dragSource.pileId === 'waste') {
+    const parsedSource = parsePileId(dragSource.pileId);
+    let movingCards: import('../game/types').Card[] = [];
+    if (parsedSource?.kind === 'waste') {
       movingCards = state.waste.length > 0 ? [state.waste[state.waste.length - 1]] : [];
-    } else if (dragSource.pileId.startsWith('tableau-')) {
-      const tabIdx = parseInt(dragSource.pileId.split('-')[1]);
-      movingCards = state.tableau[tabIdx].slice(dragSource.cardIndex);
-    } else {
-      movingCards = [];
+    } else if (parsedSource?.kind === 'tableau') {
+      movingCards = state.tableau[parsedSource.index].slice(dragSource.cardIndex);
     }
 
     if (movingCards.length > 0) {
       state.moveCards({
         cards: movingCards,
-        from: dragSource.pileId as 'waste' | `tableau-${number}`,
+        from: dragSource.pileId as PileId,
         fromIndex: dragSource.cardIndex,
-        to: targetPileId as `tableau-${number}` | `foundation-${number}`,
+        to: targetPileId as PileId,
       });
     }
   }, [cardWidth, dragApi]);

--- a/src/components/Tableau.tsx
+++ b/src/components/Tableau.tsx
@@ -2,7 +2,7 @@ import { useRef, useCallback, useState } from 'react';
 import { useGameStore } from '../game/store';
 import { findFoundationIndex, canMoveToTableau } from '../game/rules';
 import { useDropTargetValidation } from '../hooks/useDropTargetValidation';
-import type { PileId } from '../game/types';
+import { tableauId, foundationId } from '../game/pileId';
 import TableauVisual from './TableauVisual';
 
 interface TableauProps {
@@ -30,7 +30,7 @@ export default function Tableau({
   const pile = useGameStore(s => s.tableau[index]);
   const foundations = useGameStore(s => s.foundations);
   const moveCards = useGameStore(s => s.moveCards);
-  const pileId = `tableau-${index}` as PileId;
+  const pileId = tableauId(index);
   const dragIdxRef = useRef<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [isDragSource, setIsDragSource] = useState(false);
@@ -53,7 +53,7 @@ export default function Tableau({
           cards: [card],
           from: pileId,
           fromIndex: cardIndex,
-          to: `foundation-${fi}` as PileId,
+          to: foundationId(fi),
         });
       }
     },

--- a/src/game/__tests__/combatStore.test.ts
+++ b/src/game/__tests__/combatStore.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useGameStore } from '../store';
-import { useCombatStore, _resetTracking, _withSuppressedEvents, hasPlayTriggered } from '../combatStore';
+import { useCombatStore } from '../combatStore';
+import { _resetTracking, _withSuppressedEvents, hasPlayTriggered } from '../orchestrator';
 import type { Card, Rank, Suit } from '../types';
 
 function makeCard(suit: Suit, rank: Rank, faceUp = true): Card {

--- a/src/game/__tests__/dropPreview.test.ts
+++ b/src/game/__tests__/dropPreview.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { getDropPreview } from '../dropPreview';
-import { useCombatStore, _withSuppressedEvents, _resetTracking } from '../combatStore';
+import { useCombatStore } from '../combatStore';
+import { _withSuppressedEvents, _resetTracking } from '../orchestrator';
 import { useGameStore } from '../store';
 import type { Card, Rank, Suit } from '../types';
 

--- a/src/game/__tests__/pileId.test.ts
+++ b/src/game/__tests__/pileId.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { parsePileId, tableauId, foundationId } from '../pileId';
+
+describe('parsePileId', () => {
+  it('parses stock and waste', () => {
+    expect(parsePileId('stock')).toEqual({ kind: 'stock' });
+    expect(parsePileId('waste')).toEqual({ kind: 'waste' });
+  });
+
+  it('parses tableau ids and extracts the index', () => {
+    expect(parsePileId('tableau-0')).toEqual({ kind: 'tableau', index: 0 });
+    expect(parsePileId('tableau-6')).toEqual({ kind: 'tableau', index: 6 });
+  });
+
+  it('parses foundation ids and extracts the index', () => {
+    expect(parsePileId('foundation-0')).toEqual({ kind: 'foundation', index: 0 });
+    expect(parsePileId('foundation-3')).toEqual({ kind: 'foundation', index: 3 });
+  });
+
+  it('returns null for unknown shapes', () => {
+    expect(parsePileId('garbage')).toBeNull();
+    expect(parsePileId('tableau-')).toBeNull();
+    expect(parsePileId('foundation-x')).toBeNull();
+    expect(parsePileId('')).toBeNull();
+  });
+});
+
+describe('tableauId / foundationId', () => {
+  it('round-trips through parsePileId', () => {
+    for (let i = 0; i < 7; i++) {
+      const id = tableauId(i);
+      expect(id).toBe(`tableau-${i}`);
+      expect(parsePileId(id)).toEqual({ kind: 'tableau', index: i });
+    }
+    for (let i = 0; i < 4; i++) {
+      const id = foundationId(i);
+      expect(id).toBe(`foundation-${i}`);
+      expect(parsePileId(id)).toEqual({ kind: 'foundation', index: i });
+    }
+  });
+});

--- a/src/game/__tests__/store.test.ts
+++ b/src/game/__tests__/store.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useGameStore } from '../store';
-import { _withSuppressedEvents, useCombatStore } from '../combatStore';
+import { useCombatStore } from '../combatStore';
+import { _withSuppressedEvents } from '../orchestrator';
 import type { Card, Rank, Suit } from '../types';
 
 function makeCard(suit: Suit, rank: Rank, faceUp = true): Card {

--- a/src/game/autoComplete.ts
+++ b/src/game/autoComplete.ts
@@ -1,5 +1,6 @@
-import { Card, MovePayload, PileId } from './types';
+import { Card, MovePayload } from './types';
 import { canMoveToFoundation } from './rules';
+import { tableauId, foundationId } from './pileId';
 
 export function getAutoCompleteSequence(
   tableau: Card[][],
@@ -19,9 +20,9 @@ export function getAutoCompleteSequence(
         if (canMoveToFoundation(topCard, foundCopy[f])) {
           moves.push({
             cards: [topCard],
-            from: `tableau-${t}` as PileId,
+            from: tableauId(t),
             fromIndex: tabCopy[t].length - 1,
-            to: `foundation-${f}` as PileId,
+            to: foundationId(f),
           });
           tabCopy[t].pop();
           foundCopy[f].push(topCard);

--- a/src/game/combatStore.ts
+++ b/src/game/combatStore.ts
@@ -165,6 +165,4 @@ export const useCombatStore = create<CombatState & CombatActions>()((set, get) =
 
 // Cross-store wiring (event detection + run orchestration) lives in
 // `./orchestrator`. combatStore now exposes only its own state and actions
-// — see issue #34. The helpers below are re-exports kept for backward
-// compatibility with tests and dropPreview.ts.
-export { hasPlayTriggered, _resetTracking, _withSuppressedEvents } from './orchestrator';
+// — see issue #34.

--- a/src/game/dropPreview.ts
+++ b/src/game/dropPreview.ts
@@ -1,6 +1,8 @@
 import type { Card } from './types';
-import { useCombatStore, hasPlayTriggered } from './combatStore';
+import { useCombatStore } from './combatStore';
+import { hasPlayTriggered } from './orchestrator';
 import { useGameStore } from './store';
+import { parsePileId } from './pileId';
 import { FACE_NAMES, isFaceCard, RANK_ACE, RANK_JACK, RANK_QUEEN, RANK_KING } from './faceCard';
 
 // Effect descriptions per face card per tier
@@ -67,8 +69,11 @@ export function getDropPreview(cards: Card[], targetPileId: string, sourcePileId
       }
 
       // Compute source-pile side effects
-      const sourceIdx = parseInt(sourcePileId.split('-')[1]);
-      const sourcePile = useGameStore.getState().tableau[sourceIdx];
+      const parsedSource = parsePileId(sourcePileId);
+      const sourcePile =
+        parsedSource?.kind === 'tableau'
+          ? useGameStore.getState().tableau[parsedSource.index]
+          : undefined;
       if (sourcePile) {
         const fromIndex = sourcePile.findIndex(c => c.id === card.id);
         if (fromIndex >= 0) {

--- a/src/game/pileId.ts
+++ b/src/game/pileId.ts
@@ -1,0 +1,37 @@
+import type { PileId } from './types';
+
+/**
+ * Type-safe parsing/construction of pile ids. Replaces the
+ * `parseInt(id.split('-')[1])` pattern and the `as PileId` casts.
+ */
+
+export type ParsedPileId =
+  | { kind: 'stock' }
+  | { kind: 'waste' }
+  | { kind: 'tableau'; index: number }
+  | { kind: 'foundation'; index: number };
+
+export function parsePileId(id: string): ParsedPileId | null {
+  if (id === 'stock') return { kind: 'stock' };
+  if (id === 'waste') return { kind: 'waste' };
+
+  const dash = id.indexOf('-');
+  if (dash < 0) return null;
+  const prefix = id.slice(0, dash);
+  const rest = id.slice(dash + 1);
+  if (rest === '') return null;
+  const index = Number(rest);
+  if (!Number.isInteger(index) || index < 0) return null;
+
+  if (prefix === 'tableau') return { kind: 'tableau', index };
+  if (prefix === 'foundation') return { kind: 'foundation', index };
+  return null;
+}
+
+export function tableauId(index: number): PileId {
+  return `tableau-${index}` as PileId;
+}
+
+export function foundationId(index: number): PileId {
+  return `foundation-${index}` as PileId;
+}

--- a/src/game/store.ts
+++ b/src/game/store.ts
@@ -3,6 +3,7 @@ import { persist } from 'zustand/middleware';
 import { GameState, GameActions, Snapshot, MovePayload, Card } from './types';
 import { createDeck, shuffle, dealTableau } from './deck';
 import { canMoveToTableau, canMoveToFoundation, isWin } from './rules';
+import { parsePileId } from './pileId';
 
 function takeSnapshot(state: GameState): Snapshot {
   return {
@@ -33,35 +34,33 @@ function createInitialState(drawMode: 1 | 3 = 1): Omit<GameState, 'gameId'> {
 }
 
 function parsePile(pileId: string, state: GameState): Card[] {
-  if (pileId === 'stock') return state.stock;
-  if (pileId === 'waste') return state.waste;
-  if (pileId.startsWith('tableau-')) {
-    const idx = parseInt(pileId.split('-')[1]);
-    return state.tableau[idx];
+  const parsed = parsePileId(pileId);
+  if (!parsed) return [];
+  switch (parsed.kind) {
+    case 'stock': return state.stock;
+    case 'waste': return state.waste;
+    case 'tableau': return state.tableau[parsed.index];
+    case 'foundation': return state.foundations[parsed.index];
   }
-  if (pileId.startsWith('foundation-')) {
-    const idx = parseInt(pileId.split('-')[1]);
-    return state.foundations[idx];
-  }
-  return [];
 }
 
 function setPile(pileId: string, cards: Card[], state: GameState): Partial<GameState> {
-  if (pileId === 'stock') return { stock: cards };
-  if (pileId === 'waste') return { waste: cards };
-  if (pileId.startsWith('tableau-')) {
-    const idx = parseInt(pileId.split('-')[1]);
-    const tableau = [...state.tableau];
-    tableau[idx] = cards;
-    return { tableau };
+  const parsed = parsePileId(pileId);
+  if (!parsed) return {};
+  switch (parsed.kind) {
+    case 'stock': return { stock: cards };
+    case 'waste': return { waste: cards };
+    case 'tableau': {
+      const tableau = [...state.tableau];
+      tableau[parsed.index] = cards;
+      return { tableau };
+    }
+    case 'foundation': {
+      const foundations = [...state.foundations];
+      foundations[parsed.index] = cards;
+      return { foundations };
+    }
   }
-  if (pileId.startsWith('foundation-')) {
-    const idx = parseInt(pileId.split('-')[1]);
-    const foundations = [...state.foundations];
-    foundations[idx] = cards;
-    return { foundations };
-  }
-  return {};
 }
 
 export const useGameStore = create<GameState & GameActions>()(


### PR DESCRIPTION
## Summary

- New `src/game/pileId.ts` with `parsePileId` / `tableauId` / `foundationId`, replacing `parseInt(id.split('-')[1])` parsing and four `as PileId` casts across `store.ts`, `dropPreview.ts`, `GameBoard.tsx`, `Tableau.tsx`, and `autoComplete.ts`. TDD: `pileId.test.ts` (5 tests) written first.
- `Particles.tsx`: the first `useMemo` allocated and randomized `sizes` / `suits` / `colors` but only returned `velocities` / `offsets` / `rotations`, silently dropping the other three. The second `useMemo` then re-allocated and re-randomized them. Now returns all six and the geometry block reuses the originals — one fewer HSL loop and three fewer `Float32Array` allocations on mount.
- Drops the backward-compat re-exports of `hasPlayTriggered` / `_withSuppressedEvents` / `_resetTracking` from `combatStore.ts`. `dropPreview.ts` and three test files now import them directly from `orchestrator`, matching the post-#34 module boundaries.

## Test plan

- [x] `npm test` — 180 passed (up from 175; +5 pileId)
- [x] `npm run build` — clean
- [ ] Manual: drag a tableau stack and confirm drop targets still highlight correctly
- [ ] Manual: confirm the background card particles still render with varied sizes, suits, and tints