### PR TITLE
Particles: use clock elapsedTime instead of Date.now() per card

### DIFF
--- a/src/background/Particles.tsx
+++ b/src/background/Particles.tsx
@@ -119,13 +119,15 @@ export default function Particles({ combatState }: Props) {
 
   const targetTint = useMemo(() => TINT_NONE.clone(), []);
 
-  useFrame((_, delta) => {
+  useFrame((state, delta) => {
     if (!meshRef.current) return;
 
     const cs = combatState.current;
     if (!cs) return;
     const isWon = cs.isWon;
     const speed = isWon || cs.combatResult === 'victory' ? 5 : cs.combatResult === 'defeat' ? 0.3 : 1;
+    // Pull clock time once per frame instead of Date.now() per card.
+    const t = state.clock.elapsedTime;
 
     const offsetAttr = meshRef.current.geometry.attributes.aOffset;
     const off = offsetAttr.array as Float32Array;
@@ -136,7 +138,7 @@ export default function Particles({ combatState }: Props) {
       off[i * 3 + 2] += velocities[i * 3 + 2] * delta * 60 * speed;
 
       // Sinusoidal drift
-      off[i * 3] += Math.sin(Date.now() * 0.001 + i) * 0.001 * speed;
+      off[i * 3] += Math.sin(t + i) * 0.001 * speed;
 
       // Defeat: cards sink
       if (cs.combatResult === 'defeat') {


### PR DESCRIPTION
## Summary

- The sinusoidal drift inside the per-card `useFrame` loop called `Date.now()` once per card per frame (400 calls per frame at 60 Hz). Pull the elapsed time from `useFrame`'s `RootState` clock once per frame and use it for all 400 cards instead.
- After surveying the codebase, the C3 (Card.tsx `React.memo`) and C4 (`useShallow` on `CombatBar`) items in the original perf plan turned out to be misframed: `React.memo` on `Card` is defeated by `Tableau`'s inline handler closures, and `CombatBar`'s primitive zustand selectors already short-circuit re-renders via `Object.is`. They're dropped from this PR.

## Test plan

- [x] `npm test` — 175 passed
- [x] `npm run build` — clean
- [ ] Manual: confirm background particles still drift and sway naturally