### PR TITLE
Add unit tests for deck, faceCard, autoComplete

### DIFF
--- a/src/game/__tests__/autoComplete.test.ts
+++ b/src/game/__tests__/autoComplete.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { getAutoCompleteSequence } from '../autoComplete';
+import type { Card, Suit, Rank } from '../types';
+
+const card = (suit: Suit, rank: Rank, faceUp = true): Card => ({
+  id: `${suit}-${rank}`,
+  suit,
+  rank,
+  faceUp,
+});
+
+describe('getAutoCompleteSequence', () => {
+  it('returns no moves for an empty board', () => {
+    const empty4: Card[][] = [[], [], [], []];
+    const empty7: Card[][] = [[], [], [], [], [], [], []];
+    expect(getAutoCompleteSequence(empty7, empty4)).toEqual([]);
+  });
+
+  it('moves a single Ace from a tableau pile to the matching foundation', () => {
+    const tableau: Card[][] = [[], [], [], [], [], [], []];
+    tableau[2] = [card('hearts', 1)];
+    const foundations: Card[][] = [[], [], [], []];
+    const moves = getAutoCompleteSequence(tableau, foundations);
+    expect(moves).toHaveLength(1);
+    expect(moves[0].from).toBe('tableau-2');
+    expect(moves[0].to.startsWith('foundation-')).toBe(true);
+    expect(moves[0].cards).toHaveLength(1);
+    expect(moves[0].cards[0].rank).toBe(1);
+  });
+
+  it('chains consecutive ranks of the same suit from one tableau pile', () => {
+    const tableau: Card[][] = [[], [], [], [], [], [], []];
+    tableau[0] = [
+      card('clubs', 3),
+      card('clubs', 2),
+      card('clubs', 1),
+    ];
+    const foundations: Card[][] = [[], [], [], []];
+    const moves = getAutoCompleteSequence(tableau, foundations);
+    // Order must be A → 2 → 3
+    expect(moves.map(m => m.cards[0].rank)).toEqual([1, 2, 3]);
+    // All play onto the same foundation index
+    const fIds = new Set(moves.map(m => m.to));
+    expect(fIds.size).toBe(1);
+  });
+
+  it('does not produce moves when no card can play to a foundation', () => {
+    const tableau: Card[][] = [[], [], [], [], [], [], []];
+    // 5 with no preceding cards on the foundation
+    tableau[4] = [card('spades', 5)];
+    const foundations: Card[][] = [[], [], [], []];
+    expect(getAutoCompleteSequence(tableau, foundations)).toEqual([]);
+  });
+
+  it('does not mutate the input arrays', () => {
+    const tableau: Card[][] = [[], [], [], [], [], [], []];
+    tableau[1] = [card('diamonds', 1)];
+    const foundations: Card[][] = [[], [], [], []];
+    const tabSnap = tableau.map(p => p.map(c => c.id));
+    const founSnap = foundations.map(p => p.map(c => c.id));
+    getAutoCompleteSequence(tableau, foundations);
+    expect(tableau.map(p => p.map(c => c.id))).toEqual(tabSnap);
+    expect(foundations.map(p => p.map(c => c.id))).toEqual(founSnap);
+  });
+});

--- a/src/game/__tests__/deck.test.ts
+++ b/src/game/__tests__/deck.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { createDeck, shuffle, dealTableau } from '../deck';
+
+describe('createDeck', () => {
+  it('produces 52 unique cards, all face-down', () => {
+    const deck = createDeck();
+    expect(deck).toHaveLength(52);
+    const ids = new Set(deck.map(c => c.id));
+    expect(ids.size).toBe(52);
+    expect(deck.every(c => c.faceUp === false)).toBe(true);
+  });
+
+  it('contains every rank/suit combination exactly once', () => {
+    const deck = createDeck();
+    const seen = new Set<string>();
+    for (const c of deck) seen.add(`${c.suit}-${c.rank}`);
+    expect(seen.size).toBe(52);
+  });
+});
+
+describe('shuffle', () => {
+  it('returns a new array with the same cards', () => {
+    const deck = createDeck();
+    const shuffled = shuffle(deck);
+    expect(shuffled).not.toBe(deck);
+    expect(shuffled).toHaveLength(deck.length);
+    expect(new Set(shuffled.map(c => c.id))).toEqual(new Set(deck.map(c => c.id)));
+  });
+
+  it('does not mutate the input', () => {
+    const deck = createDeck();
+    const before = deck.map(c => c.id);
+    shuffle(deck);
+    expect(deck.map(c => c.id)).toEqual(before);
+  });
+});
+
+describe('dealTableau', () => {
+  it('deals 7 piles of sizes 1..7', () => {
+    const { tableau, stock } = dealTableau(createDeck());
+    expect(tableau).toHaveLength(7);
+    for (let i = 0; i < 7; i++) {
+      expect(tableau[i]).toHaveLength(i + 1);
+    }
+    // 1+2+...+7 = 28; 52 - 28 = 24 left in stock
+    expect(stock).toHaveLength(24);
+  });
+
+  it('flips only the top card of each pile face-up', () => {
+    const { tableau } = dealTableau(createDeck());
+    for (let col = 0; col < 7; col++) {
+      const pile = tableau[col];
+      for (let row = 0; row < pile.length; row++) {
+        expect(pile[row].faceUp).toBe(row === pile.length - 1);
+      }
+    }
+  });
+
+  it('leaves the entire stock face-down', () => {
+    const { stock } = dealTableau(createDeck());
+    expect(stock.every(c => c.faceUp === false)).toBe(true);
+  });
+
+  it('does not mutate the input deck', () => {
+    const deck = createDeck();
+    const before = deck.map(c => c.id);
+    dealTableau(deck);
+    expect(deck.map(c => c.id)).toEqual(before);
+  });
+});

--- a/src/game/__tests__/faceCard.test.ts
+++ b/src/game/__tests__/faceCard.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isFaceCard,
+  FACE_CARD_RANKS,
+  FACE_NAMES,
+  RANK_ACE,
+  RANK_JACK,
+  RANK_QUEEN,
+  RANK_KING,
+} from '../faceCard';
+
+describe('isFaceCard', () => {
+  it('treats Ace, Jack, Queen, King as face cards', () => {
+    for (const r of [RANK_ACE, RANK_JACK, RANK_QUEEN, RANK_KING]) {
+      expect(isFaceCard(r)).toBe(true);
+    }
+  });
+
+  it('rejects every non-face rank', () => {
+    for (let r = 2; r <= 10; r++) expect(isFaceCard(r)).toBe(false);
+  });
+});
+
+describe('FACE_NAMES / FACE_CARD_RANKS', () => {
+  it('names every face rank', () => {
+    expect(FACE_NAMES[RANK_ACE]).toBe('Ace');
+    expect(FACE_NAMES[RANK_JACK]).toBe('Jack');
+    expect(FACE_NAMES[RANK_QUEEN]).toBe('Queen');
+    expect(FACE_NAMES[RANK_KING]).toBe('King');
+  });
+
+  it('FACE_CARD_RANKS contains exactly the four ranks', () => {
+    expect(FACE_CARD_RANKS.size).toBe(4);
+    expect([...FACE_CARD_RANKS].sort()).toEqual([1, 11, 12, 13]);
+  });
+});


### PR DESCRIPTION
## Summary

These pure-logic modules in `src/game/` had no sibling `__tests__` files despite being exercised only indirectly through the store tests. Adds focused coverage:

- `deck.test.ts`: `createDeck` uniqueness, `shuffle` non-mutation, `dealTableau` pile sizes / face-up flags / stock count / non-mutation.
- `faceCard.test.ts`: `isFaceCard` truthiness for the four ranks, `FACE_NAMES` table, `FACE_CARD_RANKS` membership.
- `autoComplete.test.ts`: empty board, single Ace, A-2-3 chain order, no-op when nothing plays, input non-mutation.

Per-detector unit tests are tracked separately in #67 — they need a `DetectorContext` mock harness large enough to warrant its own PR.

## Test plan

- [x] `npm test` — 192 passed (up from 175; +17 new)
- [x] `npm run build` — clean