### PR TITLE
Metrics baseline & target envelopes (improvement loop piece 2)

### DIFF
--- a/docs/plans/2026-04-10-metrics-baseline.md
+++ b/docs/plans/2026-04-10-metrics-baseline.md
@@ -1,0 +1,575 @@
+# Metrics Baseline & Target Envelopes Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Turn raw sim output into a pass/fail signal with committed baseline snapshots and envelope comparison.
+
+**Architecture:** A `sim:baseline` script runs 2000 greedy games per difficulty, aggregates metrics, and writes `sim/baseline.json`. A `sim:compare` script runs a fresh sim, loads the baseline, checks envelope rules, and exits non-zero on violation. Envelopes are defined in `sim/envelopes.json`.
+
+**Tech Stack:** Node.js scripts (`.mjs` with tsx import), existing sim runner infrastructure.
+
+---
+
+### Task 1: Create envelope config
+
+**Files:**
+- Create: `sim/envelopes.json`
+
+**Step 1: Write the envelope config**
+
+```json
+{
+  "normal": {
+    "winRate": [0.55, 0.70],
+    "avgEncountersCleared": [4.5, null]
+  },
+  "hard": {
+    "winRate": [0.25, 0.45]
+  },
+  "nightmare": {
+    "winRate": [0.05, 0.20]
+  },
+  "global": {
+    "maxSingleDetectorDamagePct": 0.40,
+    "maxStockCycleDamagePct": 0.25,
+    "autoMergeDriftPct": 0.02
+  }
+}
+```
+
+Envelope values are `[min, max]` ranges. `null` means unbounded. Global rules apply across all difficulties.
+
+- `maxSingleDetectorDamagePct`: no single damage source (from `damageBySource`) may exceed this fraction of total damage across all runs in a difficulty.
+- `maxStockCycleDamagePct`: the `Waste!` damage source (stock-cycle threat) must not exceed this fraction of total damage.
+- `autoMergeDriftPct`: for auto-merge tier, all headline numbers must be within ±this of baseline.
+
+**Step 2: Commit**
+
+```bash
+git add sim/envelopes.json
+git commit -m "feat: add envelope config for sim metrics"
+```
+
+---
+
+### Task 2: Create the baseline generation script
+
+**Files:**
+- Create: `scripts/sim/baseline.mjs`
+- Modify: `package.json` (add `sim:baseline` script)
+
+**Step 1: Write the baseline script**
+
+`scripts/sim/baseline.mjs` should:
+1. For each difficulty (`normal`, `hard`, `nightmare`), invoke `runChunk` from `runnerCore.ts` with 2000 runs, player `greedy`, seed `1`.
+2. Aggregate per-difficulty metrics:
+   - `runs`, `wins`, `winRate`, `avgEncountersCleared`, `avgTurns`
+   - `damageBySource`: sum across all runs, then compute each source's fraction of total
+   - `healBySource`: sum across all runs
+3. Write the result to `sim/baseline.json`.
+4. Print a summary table to stderr.
+
+Structure of `sim/baseline.json`:
+```json
+{
+  "generatedAt": "2026-04-10T...",
+  "runsPerDifficulty": 2000,
+  "seed": 1,
+  "difficulties": {
+    "normal": {
+      "runs": 2000,
+      "wins": 1234,
+      "winRate": 0.617,
+      "avgEncountersCleared": 4.52,
+      "avgTurns": 98.3,
+      "damageBySource": { "Waste!": 0.42, "Reveal!": 0.25, ... },
+      "healBySource": { "hero-heal": 12345, "Column Clear!": 678 }
+    },
+    "hard": { ... },
+    "nightmare": { ... }
+  }
+}
+```
+
+The `damageBySource` values in the baseline are stored as **fractions of total damage** (not raw counts), since the envelope rules check proportions.
+
+Import the localStorage stub from `runner.mjs` by extracting it or duplicating the setup at the top of `baseline.mjs` (same pattern as runner.mjs lines 39-54).
+
+```javascript
+#!/usr/bin/env node
+import { runChunk } from './runnerCore.ts';
+import fs from 'node:fs';
+
+// localStorage stub (same as runner.mjs)
+if (typeof globalThis.window === 'undefined') {
+  const mem = new Map();
+  const storage = {
+    getItem: (k) => (mem.has(k) ? mem.get(k) : null),
+    setItem: (k, v) => { mem.set(k, String(v)); },
+    removeItem: (k) => { mem.delete(k); },
+    clear: () => { mem.clear(); },
+    key: (i) => Array.from(mem.keys())[i] ?? null,
+    get length() { return mem.size; },
+  };
+  globalThis.window = { localStorage: storage };
+  globalThis.localStorage = storage;
+}
+
+const DIFFICULTIES = ['normal', 'hard', 'nightmare'];
+const RUNS = 2000;
+const SEED = 1;
+
+function aggregateRecords(jsonLines) {
+  const records = jsonLines.map((l) => JSON.parse(l));
+  const wins = records.filter((r) => r.result === 'victory').length;
+  const avgEnc = records.reduce((s, r) => s + r.encountersCleared, 0) / records.length;
+  const avgTurns = records.reduce((s, r) => s + r.turns, 0) / records.length;
+
+  // Aggregate damage by source
+  const rawDamage = {};
+  const rawHeal = {};
+  for (const r of records) {
+    for (const [k, v] of Object.entries(r.damageBySource)) {
+      rawDamage[k] = (rawDamage[k] ?? 0) + v;
+    }
+    for (const [k, v] of Object.entries(r.healBySource)) {
+      rawHeal[k] = (rawHeal[k] ?? 0) + v;
+    }
+  }
+
+  // Convert damage to fractions
+  const totalDamage = Object.values(rawDamage).reduce((a, b) => a + b, 0);
+  const damageFractions = {};
+  for (const [k, v] of Object.entries(rawDamage)) {
+    damageFractions[k] = totalDamage > 0 ? v / totalDamage : 0;
+  }
+
+  return {
+    runs: records.length,
+    wins,
+    winRate: wins / records.length,
+    avgEncountersCleared: avgEnc,
+    avgTurns,
+    damageBySource: damageFractions,
+    healBySource: rawHeal,
+  };
+}
+
+async function main() {
+  const difficulties = {};
+
+  for (const diff of DIFFICULTIES) {
+    process.stderr.write(`Running ${RUNS} games on ${diff}...\n`);
+    const lines = await runChunk({
+      start: 0, end: RUNS, seed: SEED,
+      player: 'greedy', difficulty: diff, maxTurns: 400,
+    });
+    difficulties[diff] = aggregateRecords(lines);
+    process.stderr.write(`  ${diff}: winRate=${difficulties[diff].winRate.toFixed(3)}, avgEnc=${difficulties[diff].avgEncountersCleared.toFixed(2)}\n`);
+  }
+
+  const baseline = {
+    generatedAt: new Date().toISOString(),
+    runsPerDifficulty: RUNS,
+    seed: SEED,
+    difficulties,
+  };
+
+  fs.mkdirSync('sim', { recursive: true });
+  fs.writeFileSync('sim/baseline.json', JSON.stringify(baseline, null, 2) + '\n');
+  process.stderr.write(`\nBaseline written to sim/baseline.json\n`);
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });
+```
+
+**Step 2: Add the npm script**
+
+In `package.json`, add to `"scripts"`:
+```json
+"sim:baseline": "node --import tsx scripts/sim/baseline.mjs"
+```
+
+**Step 3: Run it to generate the baseline**
+
+```bash
+npm run sim:baseline
+```
+
+Verify `sim/baseline.json` exists with all 3 difficulties.
+
+**Step 4: Commit**
+
+```bash
+git add scripts/sim/baseline.mjs package.json sim/baseline.json
+git commit -m "feat: add baseline generation script and initial baseline"
+```
+
+---
+
+### Task 3: Create the compare script
+
+**Files:**
+- Create: `scripts/sim/compare.mjs`
+- Modify: `package.json` (add `sim:compare` script)
+
+**Step 1: Write the compare script**
+
+`scripts/sim/compare.mjs` should:
+1. Load `sim/baseline.json` and `sim/envelopes.json`.
+2. Run a fresh sim (same params as baseline: 2000 runs × 3 difficulties, seed 1).
+3. For each difficulty, check:
+   - Win rate is within the envelope range.
+   - `avgEncountersCleared` is within range (if specified).
+   - No single damage source exceeds `maxSingleDetectorDamagePct`.
+   - `Waste!` damage doesn't exceed `maxStockCycleDamagePct`.
+   - All headline numbers are within `±autoMergeDriftPct` of baseline (for auto-merge tier reporting).
+4. Print a human-readable diff table to stdout.
+5. Exit 0 if all checks pass, non-zero if any envelope is violated.
+
+```javascript
+#!/usr/bin/env node
+import fs from 'node:fs';
+
+// localStorage stub
+if (typeof globalThis.window === 'undefined') {
+  const mem = new Map();
+  const storage = {
+    getItem: (k) => (mem.has(k) ? mem.get(k) : null),
+    setItem: (k, v) => { mem.set(k, String(v)); },
+    removeItem: (k) => { mem.delete(k); },
+    clear: () => { mem.clear(); },
+    key: (i) => Array.from(mem.keys())[i] ?? null,
+    get length() { return mem.size; },
+  };
+  globalThis.window = { localStorage: storage };
+  globalThis.localStorage = storage;
+}
+
+import { runChunk } from './runnerCore.ts';
+
+function aggregateRecords(jsonLines) {
+  // Same aggregation logic as baseline.mjs — extract to shared module or duplicate
+  const records = jsonLines.map((l) => JSON.parse(l));
+  const wins = records.filter((r) => r.result === 'victory').length;
+  const avgEnc = records.reduce((s, r) => s + r.encountersCleared, 0) / records.length;
+  const avgTurns = records.reduce((s, r) => s + r.turns, 0) / records.length;
+
+  const rawDamage = {};
+  const rawHeal = {};
+  for (const r of records) {
+    for (const [k, v] of Object.entries(r.damageBySource)) {
+      rawDamage[k] = (rawDamage[k] ?? 0) + v;
+    }
+    for (const [k, v] of Object.entries(r.healBySource)) {
+      rawHeal[k] = (rawHeal[k] ?? 0) + v;
+    }
+  }
+  const totalDamage = Object.values(rawDamage).reduce((a, b) => a + b, 0);
+  const damageFractions = {};
+  for (const [k, v] of Object.entries(rawDamage)) {
+    damageFractions[k] = totalDamage > 0 ? v / totalDamage : 0;
+  }
+
+  return {
+    runs: records.length, wins,
+    winRate: wins / records.length,
+    avgEncountersCleared: avgEnc,
+    avgTurns,
+    damageBySource: damageFractions,
+    healBySource: rawHeal,
+  };
+}
+
+async function main() {
+  const baseline = JSON.parse(fs.readFileSync('sim/baseline.json', 'utf8'));
+  const envelopes = JSON.parse(fs.readFileSync('sim/envelopes.json', 'utf8'));
+  const RUNS = baseline.runsPerDifficulty;
+  const SEED = baseline.seed;
+  const DIFFICULTIES = Object.keys(baseline.difficulties);
+  const violations = [];
+  let autoMergeOk = true;
+
+  for (const diff of DIFFICULTIES) {
+    console.log(`\n=== ${diff.toUpperCase()} ===`);
+    const lines = await runChunk({
+      start: 0, end: RUNS, seed: SEED,
+      player: 'greedy', difficulty: diff, maxTurns: 400,
+    });
+    const fresh = aggregateRecords(lines);
+    const base = baseline.difficulties[diff];
+    const env = envelopes[diff] ?? {};
+    const global = envelopes.global;
+
+    // Print comparison table
+    console.log(`  metric                  baseline    fresh       delta`);
+    console.log(`  ─────────────────────── ────────── ────────── ──────────`);
+    const rows = [
+      ['winRate', base.winRate, fresh.winRate],
+      ['avgEncountersCleared', base.avgEncountersCleared, fresh.avgEncountersCleared],
+      ['avgTurns', base.avgTurns, fresh.avgTurns],
+    ];
+    for (const [name, bv, fv] of rows) {
+      const delta = fv - bv;
+      const pct = bv !== 0 ? ((delta / bv) * 100).toFixed(1) + '%' : 'N/A';
+      console.log(`  ${name.padEnd(24)}${bv.toFixed(3).padStart(10)} ${fv.toFixed(3).padStart(10)} ${(delta >= 0 ? '+' : '') + delta.toFixed(3).padStart(9)} (${pct})`);
+    }
+
+    // Damage source breakdown
+    const allSources = new Set([...Object.keys(base.damageBySource), ...Object.keys(fresh.damageBySource)]);
+    console.log(`\n  damage source           baseline    fresh`);
+    console.log(`  ─────────────────────── ────────── ──────────`);
+    for (const src of allSources) {
+      const bv = base.damageBySource[src] ?? 0;
+      const fv = fresh.damageBySource[src] ?? 0;
+      console.log(`  ${src.padEnd(24)}${(bv * 100).toFixed(1).padStart(9)}% ${(fv * 100).toFixed(1).padStart(9)}%`);
+    }
+
+    // Check envelope: win rate
+    if (env.winRate) {
+      const [lo, hi] = env.winRate;
+      if ((lo !== null && fresh.winRate < lo) || (hi !== null && fresh.winRate > hi)) {
+        violations.push(`${diff}: winRate ${fresh.winRate.toFixed(3)} outside [${lo}, ${hi}]`);
+      }
+    }
+
+    // Check envelope: avgEncountersCleared
+    if (env.avgEncountersCleared) {
+      const [lo, hi] = env.avgEncountersCleared;
+      if ((lo !== null && fresh.avgEncountersCleared < lo) || (hi !== null && fresh.avgEncountersCleared > hi)) {
+        violations.push(`${diff}: avgEncountersCleared ${fresh.avgEncountersCleared.toFixed(2)} outside [${lo}, ${hi}]`);
+      }
+    }
+
+    // Check global: no single detector > maxSingleDetectorDamagePct
+    for (const [src, frac] of Object.entries(fresh.damageBySource)) {
+      if (frac > global.maxSingleDetectorDamagePct) {
+        violations.push(`${diff}: damage source "${src}" = ${(frac * 100).toFixed(1)}% exceeds ${(global.maxSingleDetectorDamagePct * 100)}% cap`);
+      }
+    }
+
+    // Check global: stock-cycle (Waste!) damage
+    const wastePct = fresh.damageBySource['Waste!'] ?? 0;
+    if (wastePct > global.maxStockCycleDamagePct) {
+      violations.push(`${diff}: Waste! damage = ${(wastePct * 100).toFixed(1)}% exceeds ${(global.maxStockCycleDamagePct * 100)}% cap`);
+    }
+
+    // Check auto-merge drift
+    for (const [name, bv, fv] of rows) {
+      if (bv === 0) continue;
+      const drift = Math.abs((fv - bv) / bv);
+      if (drift > global.autoMergeDriftPct) {
+        autoMergeOk = false;
+      }
+    }
+  }
+
+  // Summary
+  console.log(`\n${'='.repeat(60)}`);
+  if (violations.length > 0) {
+    console.log(`\nENVELOPE VIOLATIONS (${violations.length}):`);
+    for (const v of violations) console.log(`  ✗ ${v}`);
+    console.log(`\nResult: FAIL`);
+    process.exit(1);
+  } else {
+    console.log(`\nAll envelope checks passed.`);
+    console.log(`Auto-merge eligible: ${autoMergeOk ? 'YES' : 'NO (drift > ±' + (envelopes.global.autoMergeDriftPct * 100) + '%)'}`);
+    console.log(`\nResult: PASS`);
+  }
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });
+```
+
+**Step 2: Add npm script**
+
+In `package.json`, add to `"scripts"`:
+```json
+"sim:compare": "node --import tsx scripts/sim/compare.mjs"
+```
+
+**Step 3: Run it against unmodified code — should pass**
+
+```bash
+npm run sim:compare
+```
+
+Expected: exit 0, "All envelope checks passed."
+
+Note: if envelope violations fire on the initial run (e.g. Waste! > 25%), tune the envelope values in `sim/envelopes.json` to match reality before committing. The issue says "starting values, tune after first run."
+
+**Step 4: Commit**
+
+```bash
+git add scripts/sim/compare.mjs package.json
+git commit -m "feat: add envelope comparison script"
+```
+
+---
+
+### Task 4: Extract shared aggregation logic
+
+**Files:**
+- Create: `scripts/sim/aggregate.ts`
+- Modify: `scripts/sim/baseline.mjs`
+- Modify: `scripts/sim/compare.mjs`
+
+**Step 1: Extract `aggregateRecords` into `scripts/sim/aggregate.ts`**
+
+Both baseline.mjs and compare.mjs duplicate the aggregation logic. Extract it into a shared module.
+
+```typescript
+export interface AggregatedMetrics {
+  runs: number;
+  wins: number;
+  winRate: number;
+  avgEncountersCleared: number;
+  avgTurns: number;
+  damageBySource: Record<string, number>; // fractions
+  healBySource: Record<string, number>;   // raw totals
+}
+
+export function aggregateRecords(jsonLines: string[]): AggregatedMetrics {
+  const records = jsonLines.map((l) => JSON.parse(l));
+  const wins = records.filter((r: any) => r.result === 'victory').length;
+  const avgEnc = records.reduce((s: number, r: any) => s + r.encountersCleared, 0) / records.length;
+  const avgTurns = records.reduce((s: number, r: any) => s + r.turns, 0) / records.length;
+
+  const rawDamage: Record<string, number> = {};
+  const rawHeal: Record<string, number> = {};
+  for (const r of records) {
+    for (const [k, v] of Object.entries((r as any).damageBySource)) {
+      rawDamage[k] = (rawDamage[k] ?? 0) + (v as number);
+    }
+    for (const [k, v] of Object.entries((r as any).healBySource)) {
+      rawHeal[k] = (rawHeal[k] ?? 0) + (v as number);
+    }
+  }
+  const totalDamage = Object.values(rawDamage).reduce((a, b) => a + b, 0);
+  const damageFractions: Record<string, number> = {};
+  for (const [k, v] of Object.entries(rawDamage)) {
+    damageFractions[k] = totalDamage > 0 ? v / totalDamage : 0;
+  }
+
+  return { runs: records.length, wins, winRate: wins / records.length, avgEncountersCleared: avgEnc, avgTurns, damageBySource: damageFractions, healBySource: rawHeal };
+}
+```
+
+**Step 2: Update baseline.mjs and compare.mjs to import from aggregate.ts**
+
+Replace the inline `aggregateRecords` function with:
+```javascript
+import { aggregateRecords } from './aggregate.ts';
+```
+
+**Step 3: Run both scripts to verify they still work**
+
+```bash
+npm run sim:baseline
+npm run sim:compare
+```
+
+**Step 4: Commit**
+
+```bash
+git add scripts/sim/aggregate.ts scripts/sim/baseline.mjs scripts/sim/compare.mjs
+git commit -m "refactor: extract shared aggregation logic"
+```
+
+---
+
+### Task 5: Verify with a hand-introduced regression
+
+**Step 1: Temporarily break a monster stat**
+
+In `src/combat/monsters.ts`, find the Slime definition and change `maxHp` to `4` (or similar easy-to-find value).
+
+**Step 2: Run compare**
+
+```bash
+npm run sim:compare
+```
+
+Expected: exit non-zero, at least one envelope violation printed.
+
+**Step 3: Revert the change**
+
+```bash
+git checkout src/combat/monsters.ts
+```
+
+**Step 4: Verify clean compare passes**
+
+```bash
+npm run sim:compare
+```
+
+Expected: exit 0. No commit needed for this task — it's just verification.
+
+---
+
+### Task 6: Update docs/simulation.md
+
+**Files:**
+- Modify: `docs/simulation.md`
+
+**Step 1: Add baseline & envelope documentation**
+
+Append to `docs/simulation.md` after the "Non-goals" section:
+
+```markdown
+## Metrics baseline
+
+A committed snapshot (`sim/baseline.json`) captures aggregate metrics from
+2000 greedy runs × 3 difficulties. It's the reference point for detecting
+balance regressions.
+
+### Generating the baseline
+
+```sh
+npm run sim:baseline
+```
+
+This overwrites `sim/baseline.json`. Commit the result as part of any
+human-reviewed balance PR.
+
+### Comparing against the baseline
+
+```sh
+npm run sim:compare
+```
+
+Runs a fresh sim with the same parameters as the baseline, prints a
+human-readable diff table, and exits non-zero if any envelope is violated.
+
+### Envelopes
+
+Target envelopes are defined in `sim/envelopes.json`. Each difficulty can
+specify `[min, max]` ranges for headline metrics. Global rules apply
+across all difficulties:
+
+| rule | meaning |
+|---|---|
+| `maxSingleDetectorDamagePct` | No single damage source may exceed this fraction of total damage |
+| `maxStockCycleDamagePct` | `Waste!` (stock-cycle) damage must stay below this fraction |
+| `autoMergeDriftPct` | Auto-merge tier: all headline numbers within ±this of baseline |
+
+### Baseline update policy
+
+- **Human-reviewed balance PRs:** regenerate and commit the baseline.
+- **Auto-merge PRs:** must stay within the ±2% drift window; do **not**
+  update the baseline.
+- A weekly scheduled job re-runs the sim against `main` and fails loudly
+  if headline metrics drift without an intervening balance PR.
+```
+
+**Step 2: Remove the "piece 2" line from Non-goals**
+
+Delete the line about baseline snapshots from the Non-goals section since it's now implemented.
+
+**Step 3: Commit**
+
+```bash
+git add docs/simulation.md
+git commit -m "docs: add baseline and envelope documentation"
+```

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -90,9 +90,51 @@ scripts/sim/
 Each worker imports its own copy of the store singletons, so runs in
 different workers never share state.
 
+## Metrics baseline
+
+A committed snapshot (`sim/baseline.json`) captures aggregate metrics from
+2000 greedy runs × 3 difficulties. It's the reference point for detecting
+balance regressions.
+
+### Generating the baseline
+
+```sh
+npm run sim:baseline
+```
+
+This overwrites `sim/baseline.json`. Commit the result as part of any
+human-reviewed balance PR.
+
+### Comparing against the baseline
+
+```sh
+npm run sim:compare
+```
+
+Runs a fresh sim with the same parameters as the baseline, prints a
+human-readable diff table, and exits non-zero if any envelope is violated.
+
+### Envelopes
+
+Target envelopes are defined in `sim/envelopes.json`. Each difficulty can
+specify `[min, max]` ranges for headline metrics (`null` = unbounded).
+Global rules apply across all difficulties:
+
+| rule | meaning |
+|---|---|
+| `maxSingleDetectorDamagePct` | No single damage source may exceed this fraction of total damage |
+| `maxStockCycleDamagePct` | `Waste!` (stock-cycle) damage must stay below this fraction |
+| `autoMergeDriftPct` | Auto-merge tier: all headline numbers within ±this of baseline |
+
+### Baseline update policy
+
+- **Human-reviewed balance PRs:** regenerate and commit the baseline.
+- **Auto-merge PRs:** must stay within the ±2% drift window; do **not**
+  update the baseline.
+- A weekly scheduled job re-runs the sim against `main` and fails loudly
+  if headline metrics drift without an intervening balance PR.
+
 ## Non-goals (tracked in later pieces)
 
-- Baseline snapshots and envelope comparison (`sim/baseline.json`) —
-  **piece 2**.
 - Agent roles that consume the sim — **piece 3**.
 - GitHub Actions nightly orchestration — **piece 4**.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "sim": "node --import tsx scripts/sim/runner.mjs",
+    "sim:baseline": "node --import tsx scripts/sim/baseline.mjs",
+    "sim:compare": "node --import tsx scripts/sim/compare.mjs",
     "typecheck": "node scripts/generate-build-info.js && tsc --noEmit"
   },
   "dependencies": {

--- a/scripts/sim/aggregate.ts
+++ b/scripts/sim/aggregate.ts
@@ -9,6 +9,9 @@ export interface AggregatedMetrics {
 }
 
 export function aggregateRecords(jsonLines: string[]): AggregatedMetrics {
+  if (jsonLines.length === 0) {
+    throw new Error('aggregateRecords: no records to aggregate');
+  }
   const records = jsonLines.map((l) => JSON.parse(l));
   const wins = records.filter((r: any) => r.result === 'victory').length;
   const avgEnc = records.reduce((s: number, r: any) => s + r.encountersCleared, 0) / records.length;

--- a/scripts/sim/aggregate.ts
+++ b/scripts/sim/aggregate.ts
@@ -1,0 +1,42 @@
+export interface AggregatedMetrics {
+  runs: number;
+  wins: number;
+  winRate: number;
+  avgEncountersCleared: number;
+  avgTurns: number;
+  damageBySource: Record<string, number>; // fractions of total
+  healBySource: Record<string, number>;   // raw totals
+}
+
+export function aggregateRecords(jsonLines: string[]): AggregatedMetrics {
+  const records = jsonLines.map((l) => JSON.parse(l));
+  const wins = records.filter((r: any) => r.result === 'victory').length;
+  const avgEnc = records.reduce((s: number, r: any) => s + r.encountersCleared, 0) / records.length;
+  const avgTurns = records.reduce((s: number, r: any) => s + r.turns, 0) / records.length;
+
+  const rawDamage: Record<string, number> = {};
+  const rawHeal: Record<string, number> = {};
+  for (const r of records) {
+    for (const [k, v] of Object.entries((r as any).damageBySource)) {
+      rawDamage[k] = (rawDamage[k] ?? 0) + (v as number);
+    }
+    for (const [k, v] of Object.entries((r as any).healBySource)) {
+      rawHeal[k] = (rawHeal[k] ?? 0) + (v as number);
+    }
+  }
+  const totalDamage = Object.values(rawDamage).reduce((a, b) => a + b, 0);
+  const damageFractions: Record<string, number> = {};
+  for (const [k, v] of Object.entries(rawDamage)) {
+    damageFractions[k] = totalDamage > 0 ? v / totalDamage : 0;
+  }
+
+  return {
+    runs: records.length,
+    wins,
+    winRate: wins / records.length,
+    avgEncountersCleared: avgEnc,
+    avgTurns,
+    damageBySource: damageFractions,
+    healBySource: rawHeal,
+  };
+}

--- a/scripts/sim/baseline.mjs
+++ b/scripts/sim/baseline.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Baseline generator — runs 2000 greedy games per difficulty and writes
+ * aggregated metrics to sim/baseline.json.
+ *
+ * Usage:
+ *   npm run sim:baseline
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+// Stub localStorage before any store imports.
+if (typeof globalThis.window === 'undefined') {
+  const mem = new Map();
+  const storage = {
+    getItem: (k) => (mem.has(k) ? mem.get(k) : null),
+    setItem: (k, v) => { mem.set(k, String(v)); },
+    removeItem: (k) => { mem.delete(k); },
+    clear: () => { mem.clear(); },
+    key: (i) => Array.from(mem.keys())[i] ?? null,
+    get length() { return mem.size; },
+  };
+  globalThis.window = { localStorage: storage };
+  globalThis.localStorage = storage;
+}
+
+const { runChunk } = await import('./runnerCore.ts');
+const { aggregateRecords } = await import('./aggregate.ts');
+
+const DIFFICULTIES = ['normal', 'hard', 'nightmare'];
+const RUNS_PER_DIFFICULTY = 2000;
+const SEED = 1;
+const MAX_TURNS = 400;
+
+const difficulties = {};
+
+for (const difficulty of DIFFICULTIES) {
+  process.stderr.write(`[baseline] Running ${RUNS_PER_DIFFICULTY} games on ${difficulty}...\n`);
+  const lines = await runChunk({
+    start: 0,
+    end: RUNS_PER_DIFFICULTY,
+    seed: SEED,
+    player: 'greedy',
+    difficulty,
+    maxTurns: MAX_TURNS,
+  });
+  process.stderr.write(`[baseline] ${difficulty}: ${lines.length} games done\n`);
+  difficulties[difficulty] = aggregateRecords(lines);
+}
+
+const baseline = {
+  generatedAt: new Date().toISOString(),
+  runsPerDifficulty: RUNS_PER_DIFFICULTY,
+  seed: SEED,
+  difficulties,
+};
+
+const outPath = path.join(repoRoot, 'sim', 'baseline.json');
+fs.mkdirSync(path.dirname(outPath), { recursive: true });
+fs.writeFileSync(outPath, JSON.stringify(baseline, null, 2) + '\n');
+process.stderr.write(`[baseline] Written to ${outPath}\n`);

--- a/scripts/sim/baseline.mjs
+++ b/scripts/sim/baseline.mjs
@@ -57,6 +57,7 @@ const baseline = {
   generatedAt: new Date().toISOString(),
   runsPerDifficulty: RUNS_PER_DIFFICULTY,
   seed: SEED,
+  maxTurns: MAX_TURNS,
   difficulties,
 };
 

--- a/scripts/sim/compare.mjs
+++ b/scripts/sim/compare.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * Sim compare — re-runs the baseline simulation and checks results against
+ * sim/envelopes.json constraints and the baseline for auto-merge drift.
+ *
+ * Usage:
+ *   npm run sim:compare
+ *
+ * Exit codes:
+ *   0 — all checks pass
+ *   1 — one or more violations
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+// Stub localStorage before any store imports.
+if (typeof globalThis.window === 'undefined') {
+  const mem = new Map();
+  const storage = {
+    getItem: (k) => (mem.has(k) ? mem.get(k) : null),
+    setItem: (k, v) => { mem.set(k, String(v)); },
+    removeItem: (k) => { mem.delete(k); },
+    clear: () => { mem.clear(); },
+    key: (i) => Array.from(mem.keys())[i] ?? null,
+    get length() { return mem.size; },
+  };
+  globalThis.window = { localStorage: storage };
+  globalThis.localStorage = storage;
+}
+
+const { runChunk } = await import('./runnerCore.ts');
+const { aggregateRecords } = await import('./aggregate.ts');
+
+const baselinePath = path.join(repoRoot, 'sim', 'baseline.json');
+const envelopesPath = path.join(repoRoot, 'sim', 'envelopes.json');
+
+if (!fs.existsSync(baselinePath)) {
+  console.error('sim/baseline.json not found — run "npm run sim:baseline" first');
+  process.exit(1);
+}
+
+const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
+const envelopes = JSON.parse(fs.readFileSync(envelopesPath, 'utf8'));
+
+const { runsPerDifficulty, seed } = baseline;
+const global_ = envelopes.global ?? {};
+const maxSingleDetectorPct = global_.maxSingleDetectorDamagePct ?? 1.0;
+const maxStockCyclePct = global_.maxStockCycleDamagePct ?? 1.0;
+const driftPct = global_.autoMergeDriftPct ?? 0.05;
+
+const DIFFICULTIES = ['normal', 'hard', 'nightmare'];
+
+const violations = [];
+const rows = [];
+
+for (const difficulty of DIFFICULTIES) {
+  process.stderr.write(`[compare] Running ${runsPerDifficulty} games on ${difficulty}...\n`);
+  const lines = await runChunk({
+    start: 0,
+    end: runsPerDifficulty,
+    seed,
+    player: 'greedy',
+    difficulty,
+    maxTurns: 400,
+  });
+  process.stderr.write(`[compare] ${difficulty}: ${lines.length} games done\n`);
+
+  const m = aggregateRecords(lines);
+  const base = baseline.difficulties[difficulty];
+  const env = envelopes[difficulty] ?? {};
+
+  // --- Envelope checks ---
+
+  // Win rate bounds
+  if (env.winRate) {
+    const [lo, hi] = env.winRate;
+    if (lo !== null && m.winRate < lo) {
+      violations.push(`${difficulty}: winRate ${pct(m.winRate)} below floor ${pct(lo)}`);
+    }
+    if (hi !== null && m.winRate > hi) {
+      violations.push(`${difficulty}: winRate ${pct(m.winRate)} above ceiling ${pct(hi)}`);
+    }
+  }
+
+  // avgEncountersCleared bounds
+  if (env.avgEncountersCleared) {
+    const [lo, hi] = env.avgEncountersCleared;
+    if (lo !== null && m.avgEncountersCleared < lo) {
+      violations.push(`${difficulty}: avgEncountersCleared ${m.avgEncountersCleared.toFixed(2)} below floor ${lo}`);
+    }
+    if (hi !== null && m.avgEncountersCleared > hi) {
+      violations.push(`${difficulty}: avgEncountersCleared ${m.avgEncountersCleared.toFixed(2)} above ceiling ${hi}`);
+    }
+  }
+
+  // Single damage source cap
+  for (const [src, frac] of Object.entries(m.damageBySource)) {
+    if (frac > maxSingleDetectorPct) {
+      violations.push(`${difficulty}: damage source "${src}" = ${pct(frac)} exceeds maxSingleDetectorDamagePct ${pct(maxSingleDetectorPct)}`);
+    }
+  }
+
+  // Waste!/stock-cycle damage cap
+  const wasteFrac = m.damageBySource['Waste!'] ?? 0;
+  if (wasteFrac > maxStockCyclePct) {
+    violations.push(`${difficulty}: "Waste!" damage = ${pct(wasteFrac)} exceeds maxStockCycleDamagePct ${pct(maxStockCyclePct)}`);
+  }
+
+  // --- Auto-merge drift checks (vs baseline) ---
+  const driftViolations = [];
+  if (base) {
+    const headlineChecks = [
+      ['winRate', m.winRate, base.winRate],
+      ['avgEncountersCleared', m.avgEncountersCleared, base.avgEncountersCleared],
+      ['avgTurns', m.avgTurns, base.avgTurns],
+    ];
+    for (const [label, cur, ref] of headlineChecks) {
+      if (ref === 0) continue;
+      const drift = Math.abs(cur - ref) / Math.abs(ref);
+      if (drift > driftPct) {
+        driftViolations.push(`${label} drifted ${pct(drift)} from baseline (cur=${cur.toFixed(3)}, base=${ref.toFixed(3)})`);
+      }
+    }
+  }
+
+  for (const dv of driftViolations) {
+    violations.push(`${difficulty}: ${dv}`);
+  }
+
+  // --- Build comparison row ---
+  const baseWinRate = base ? pct(base.winRate) : 'N/A';
+  const baseEnc = base ? base.avgEncountersCleared.toFixed(2) : 'N/A';
+  const baseTurns = base ? base.avgTurns.toFixed(1) : 'N/A';
+
+  rows.push({
+    difficulty,
+    winRate: `${pct(m.winRate)} (base: ${baseWinRate})`,
+    avgEnc: `${m.avgEncountersCleared.toFixed(2)} (base: ${baseEnc})`,
+    avgTurns: `${m.avgTurns.toFixed(1)} (base: ${baseTurns})`,
+    wasteDmg: pct(wasteFrac),
+    driftViolations,
+  });
+}
+
+// --- Print table ---
+console.log('\n=== Sim Compare Results ===\n');
+for (const row of rows) {
+  console.log(`[${row.difficulty.toUpperCase()}]`);
+  console.log(`  Win rate:              ${row.winRate}`);
+  console.log(`  Avg encounters:        ${row.avgEnc}`);
+  console.log(`  Avg turns:             ${row.avgTurns}`);
+  console.log(`  Waste! damage share:   ${row.wasteDmg}`);
+  if (row.driftViolations.length > 0) {
+    console.log(`  DRIFT: ${row.driftViolations.join('; ')}`);
+  }
+}
+
+if (violations.length === 0) {
+  console.log('\nAll checks PASSED.\n');
+  process.exit(0);
+} else {
+  console.log('\nVIOLATIONS:');
+  for (const v of violations) {
+    console.log(`  - ${v}`);
+  }
+  console.log('');
+  process.exit(1);
+}
+
+function pct(n) {
+  return `${(n * 100).toFixed(1)}%`;
+}

--- a/scripts/sim/compare.mjs
+++ b/scripts/sim/compare.mjs
@@ -47,13 +47,19 @@ if (!fs.existsSync(baselinePath)) {
 const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
 const envelopes = JSON.parse(fs.readFileSync(envelopesPath, 'utf8'));
 
-const { runsPerDifficulty, seed } = baseline;
+const { runsPerDifficulty, seed, maxTurns = 400 } = baseline;
 const global_ = envelopes.global ?? {};
 const maxSingleDetectorPct = global_.maxSingleDetectorDamagePct ?? 1.0;
 const maxStockCyclePct = global_.maxStockCycleDamagePct ?? 1.0;
 const driftPct = global_.autoMergeDriftPct ?? 0.05;
 
 const DIFFICULTIES = ['normal', 'hard', 'nightmare'];
+
+for (const d of DIFFICULTIES) {
+  if (!envelopes[d]) {
+    process.stderr.write(`[compare] warning: no envelope entry for difficulty "${d}" — all checks will pass\n`);
+  }
+}
 
 const violations = [];
 const rows = [];
@@ -66,7 +72,7 @@ for (const difficulty of DIFFICULTIES) {
     seed,
     player: 'greedy',
     difficulty,
-    maxTurns: 400,
+    maxTurns,
   });
   process.stderr.write(`[compare] ${difficulty}: ${lines.length} games done\n`);
 

--- a/sim/baseline.json
+++ b/sim/baseline.json
@@ -1,0 +1,81 @@
+{
+  "generatedAt": "2026-04-11T00:45:52.836Z",
+  "runsPerDifficulty": 2000,
+  "seed": 1,
+  "difficulties": {
+    "normal": {
+      "runs": 2000,
+      "wins": 173,
+      "winRate": 0.0865,
+      "avgEncountersCleared": 2.512,
+      "avgTurns": 97.2515,
+      "damageBySource": {
+        "hero-attack": 0.1119659203152318,
+        "Reveal!": 0.18811436660486686,
+        "Poison!": 0.051452295307969007,
+        "Waste!": 0.6082235990724748,
+        "Combo x3!": 0.018841016052101985,
+        "Combo x4!": 0.011282425087549718,
+        "Combo x7!": 0.0011831756646119554,
+        "Combo x5!": 0.005387674901358011,
+        "Combo x6!": 0.002630453040074794,
+        "Combo x9!": 0.00009507661590631785,
+        "Combo x8!": 0.0007183566535144014,
+        "Combo x10!": 0.00010564068434035316
+      },
+      "healBySource": {
+        "hero-heal": 62438,
+        "Column Clear!": 9115
+      }
+    },
+    "hard": {
+      "runs": 2000,
+      "wins": 0,
+      "winRate": 0,
+      "avgEncountersCleared": 1.0495,
+      "avgTurns": 56.178,
+      "damageBySource": {
+        "hero-attack": 0.11223276557168693,
+        "Reveal!": 0.1956203847538004,
+        "Poison!": 0.05256084950140536,
+        "Waste!": 0.5972111499337182,
+        "Combo x3!": 0.019980229321647072,
+        "Combo x5!": 0.006195419944696766,
+        "Combo x4!": 0.010969537666786627,
+        "Combo x6!": 0.00284260444521381,
+        "Combo x8!": 0.000655985641203187,
+        "Combo x11!": 0.00010022002851715356,
+        "Combo x7!": 0.001466856781023793,
+        "Combo x9!": 0.00016399641030079675
+      },
+      "healBySource": {
+        "hero-heal": 36721,
+        "Column Clear!": 5330
+      }
+    },
+    "nightmare": {
+      "runs": 2000,
+      "wins": 0,
+      "winRate": 0,
+      "avgEncountersCleared": 0.468,
+      "avgTurns": 39.464,
+      "damageBySource": {
+        "hero-attack": 0.11308408816812501,
+        "Reveal!": 0.19867337250776218,
+        "Poison!": 0.054258294629339766,
+        "Waste!": 0.5866541787483001,
+        "Combo x3!": 0.021092607323394318,
+        "Combo x5!": 0.005965974699135255,
+        "Combo x4!": 0.013291935028611018,
+        "Combo x6!": 0.004233917528418568,
+        "Combo x7!": 0.0017962074362987863,
+        "Combo x8!": 0.0007184829745195146,
+        "Combo x9!": 0.00023094095609555823
+      },
+      "healBySource": {
+        "hero-heal": 26207,
+        "Column Clear!": 3880
+      }
+    }
+  }
+}

--- a/sim/baseline.json
+++ b/sim/baseline.json
@@ -1,7 +1,8 @@
 {
-  "generatedAt": "2026-04-11T00:45:52.836Z",
+  "generatedAt": "2026-04-11T00:49:42.981Z",
   "runsPerDifficulty": 2000,
   "seed": 1,
+  "maxTurns": 400,
   "difficulties": {
     "normal": {
       "runs": 2000,

--- a/sim/envelopes.json
+++ b/sim/envelopes.json
@@ -1,0 +1,17 @@
+{
+  "normal": {
+    "winRate": [0.55, 0.70],
+    "avgEncountersCleared": [4.5, null]
+  },
+  "hard": {
+    "winRate": [0.25, 0.45]
+  },
+  "nightmare": {
+    "winRate": [0.05, 0.20]
+  },
+  "global": {
+    "maxSingleDetectorDamagePct": 0.40,
+    "maxStockCycleDamagePct": 0.25,
+    "autoMergeDriftPct": 0.02
+  }
+}

--- a/sim/envelopes.json
+++ b/sim/envelopes.json
@@ -1,17 +1,17 @@
 {
   "normal": {
-    "winRate": [0.55, 0.70],
-    "avgEncountersCleared": [4.5, null]
+    "winRate": [0.05, 0.15],
+    "avgEncountersCleared": [2.0, null]
   },
   "hard": {
-    "winRate": [0.25, 0.45]
+    "winRate": [0.0, 0.05]
   },
   "nightmare": {
-    "winRate": [0.05, 0.20]
+    "winRate": [0.0, 0.02]
   },
   "global": {
-    "maxSingleDetectorDamagePct": 0.40,
-    "maxStockCycleDamagePct": 0.25,
+    "maxSingleDetectorDamagePct": 0.70,
+    "maxStockCycleDamagePct": 0.70,
     "autoMergeDriftPct": 0.02
   }
 }


### PR DESCRIPTION
## Summary

Closes #77. Depends on #76 (headless simulator, merged in #81).

- `sim/envelopes.json` — target envelope config (win rate ranges per difficulty, damage source caps, auto-merge drift threshold)
- `scripts/sim/baseline.mjs` — generates `sim/baseline.json` from 2000 greedy runs × 3 difficulties
- `scripts/sim/compare.mjs` — re-runs sim, checks against envelopes and baseline drift, exits non-zero on violation
- `scripts/sim/aggregate.ts` — shared metrics aggregation module
- `sim/baseline.json` — committed baseline snapshot
- Updated `docs/simulation.md` with envelope and baseline documentation

Envelope values were tuned to match the greedy player's actual performance (e.g. ~8.6% normal win rate, not the aspirational 55-70% from the issue).

## Test plan

- [x] `npm run sim:baseline` generates baseline successfully
- [x] `npm run sim:compare` exits 0 on unmodified code
- [x] Hand-introduced regression (Slime maxHp: 4) causes `sim:compare` to exit 1 with clear violation messages
- [x] Reverted regression, `sim:compare` exits 0 again

🤖 Generated with [Claude Code](https://claude.com/claude-code)